### PR TITLE
add yaml separator for generated manifest.

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -119,6 +119,10 @@ func renderChart(namespace, baseValues, overlayValues string, chrt *chart.Chart)
 
 	var sb strings.Builder
 	for _, f := range files {
+		// add yaml separater if the rendered file doesn't have one at the end
+		if !strings.HasSuffix(strings.TrimSpace(f)+"\n", YAMLSeparator) {
+			f += YAMLSeparator
+		}
 		_, err := sb.WriteString(f + YAMLSeparator)
 		if err != nil {
 			return "", err

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -119,7 +119,7 @@ func renderChart(namespace, baseValues, overlayValues string, chrt *chart.Chart)
 
 	var sb strings.Builder
 	for _, f := range files {
-		_, err := sb.WriteString(f)
+		_, err := sb.WriteString(f + YAMLSeparator)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Resolve: https://github.com/istio/istio/issues/15370


Currently if you generate the yaml manifests with default profile:

```
#./iop manifest > istio.yaml
```

You will find the yaml is invalid because there are some missing yaml separator:

```
# kubectl apply -f istio.yaml.old
error: error validating "istio.yaml.old": error validating data: [ValidationError(ClusterRole): unknown field "roleRef" in io.k8s.api.rbac.v1.ClusterRole, ValidationError(ClusterRole): unknown field "spec" in io.k8s.api.rbac.v1.ClusterRole, ValidationError(ClusterRole): unknown field "subjects" in io.k8s.api.rbac.v1.ClusterRole]; if you choose to ignore these errors, turn validation off with --validate=false
```

Check the generated yaml manifests:
```
...
          - weight: 2
            preference:
              matchExpressions:
              - key: beta.kubernetes.io/arch
                operator: In
                values:
                - s390x
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: istio-nodeagent-istio-system
  labels:
    app: istio-nodeagent
    release: istio
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: istio-nodeagent-istio-system
subjects:
  - kind: ServiceAccount
    name: istio-nodeagent-service-account
    namespace: istio-system
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: istio-nodeagent-istio-system
  labels:
    app: istio-nodeagent
    release: istio
rules:
- apiGroups: [""]
  resources: ["configmaps"]
  verbs: ["get"]
...
```

This PR is to add yaml separator for each yaml file rendered by the helm engine.