### PR TITLE
Add error logs for various scenarios. Update existing log messages and…

### DIFF
--- a/cmd/iop/install.go
+++ b/cmd/iop/install.go
@@ -23,6 +23,8 @@ import (
 
 	"istio.io/operator/pkg/manifest"
 	"istio.io/operator/pkg/version"
+
+	"istio.io/pkg/log"
 )
 
 func installCmd(rootArgs *rootArgs) *cobra.Command {
@@ -46,28 +48,26 @@ func installManifests(args *rootArgs) {
 
 	manifests, err := genManifests(args)
 	if err != nil {
-		logAndPrintf(args, "%s", err)
-		os.Exit(1)
+		log.Fatalf("Could not generate manifest: %v", err)
 	}
 
 	out, err := manifest.ApplyAll(manifests, version.NewVersion("", 1, 2, 0, ""), args.dryRun, args.verbose)
 	if err != nil {
-		logAndPrintf(args, "%s", err)
-		os.Exit(1)
+		log.Fatalf("Failed to apply manifest with kubectl client: %v", err)
 	}
 
 	for cn := range manifests {
 
 		cs := fmt.Sprintf("CompositeOutput for component %s:", cn)
-		logAndPrintf(args, "\n%s\n%s", cs, strings.Repeat("=", len(cs)))
+		log.Infof("\n%s\n%s", cs, strings.Repeat("=", len(cs)))
 		if out.Err[cn] != nil {
-			logAndPrintf(args, "Errors: %s\n", out.Err[cn])
+			log.Errorf("Error object: %s\n", out.Err[cn])
 		}
 		if strings.TrimSpace(out.Stderr[cn]) != "" {
-			logAndPrintf(args, "Error strings:\n%s\n", out.Stderr[cn])
+			log.Errorf("Error string:\n%s\n", out.Stderr[cn])
 		}
 		if strings.TrimSpace(out.Stdout[cn]) != "" {
-			logAndPrintf(args, "Command output:\n%s\n", out.Stdout[cn])
+			log.Infof("Output:\n%s\n", out.Stdout[cn])
 		}
 	}
 }

--- a/cmd/iop/manifest.go
+++ b/cmd/iop/manifest.go
@@ -45,7 +45,7 @@ func writeManifests(args *rootArgs) {
 
 	manifests, err := genManifests(args)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatalf("Could not generate manifests: %s", err)
 	}
 
 	if args.outFilename == "" {
@@ -54,10 +54,10 @@ func writeManifests(args *rootArgs) {
 		}
 	} else {
 		if err := os.MkdirAll(args.outFilename, os.ModePerm); err != nil {
-			log.Fatalf(err.Error())
+			log.Fatalf("Could not create output folder: %s", err)
 		}
 		if err := manifest.RenderToDir(manifests, args.outFilename, args.dryRun, args.verbose); err != nil {
-			log.Errorf(err.Error())
+			log.Errorf("Could not render manifests to output folder: %s", err)
 		}
 	}
 }

--- a/cmd/iop/root.go
+++ b/cmd/iop/root.go
@@ -37,7 +37,7 @@ type rootArgs struct {
 
 func addFlags(cmd *cobra.Command, rootArgs *rootArgs) {
 	cmd.PersistentFlags().StringVarP(&rootArgs.inFilename, "filename", "f", "",
-		"The path to the input IstioIstall CR. Uses in cluster value with kubectl if unset.")
+		"The path to the input Istio install CR. Uses in cluster value with kubectl if unset.")
 	cmd.PersistentFlags().StringVarP(&rootArgs.outFilename, "output", "o",
 		"", "Manifest output path.")
 	cmd.PersistentFlags().BoolVarP(&rootArgs.logToStdErr, "logtostderr", "",

--- a/cmd/iop/root.go
+++ b/cmd/iop/root.go
@@ -37,7 +37,7 @@ type rootArgs struct {
 
 func addFlags(cmd *cobra.Command, rootArgs *rootArgs) {
 	cmd.PersistentFlags().StringVarP(&rootArgs.inFilename, "filename", "f", "",
-		"The path to the input Istio install CR. Uses in cluster value with kubectl if unset.")
+		"The path to the input IstioInstall CR. Uses in cluster value with kubectl if unset.")
 	cmd.PersistentFlags().StringVarP(&rootArgs.outFilename, "output", "o",
 		"", "Manifest output path.")
 	cmd.PersistentFlags().BoolVarP(&rootArgs.logToStdErr, "logtostderr", "",

--- a/cmd/iop/shared.go
+++ b/cmd/iop/shared.go
@@ -126,7 +126,7 @@ func genManifests(args *rootArgs) (name.ManifestMap, error) {
 	}
 
 	if yd := util.YAMLDiff(mergedYAML, util.ToYAMLWithJSONPB(mergedICPS)); yd != "" {
-		return nil, fmt.Errorf("Merged YAML differs from merged spec: \n%s\n", yd)
+		return nil, fmt.Errorf("merged YAML differs from merged spec: \n%s", yd)
 	}
 
 	log.Infof("Start running Istio control plane.")

--- a/cmd/iop/shared.go
+++ b/cmd/iop/shared.go
@@ -85,14 +85,13 @@ func genManifests(args *rootArgs) (name.ManifestMap, error) {
 		return nil, errs.ToError()
 	}
 
-	// Now read the base profile specified in the user spec. If nothing specified, use default.
-	baseYAML, err := helm.ReadValuesYAML(overlayICPS.Profile)
-
 	baseProfileName := overlayICPS.Profile
 	if baseProfileName == "" {
 		baseProfileName = "[Builtin Profile]"
 	}
 
+	// Now read the base profile specified in the user spec. If nothing specified, use default.
+	baseYAML, err := helm.ReadValuesYAML(overlayICPS.Profile)
 	if err != nil {
 		log.Errorf("Error reading YAML from profile: %s", baseProfileName)
 		return nil, err
@@ -143,9 +142,4 @@ func genManifests(args *rootArgs) (name.ManifestMap, error) {
 		return manifests, errs.ToError()
 	}
 	return manifests, nil
-}
-
-func logAndFatalf(args *rootArgs, v ...interface{}) {
-	logAndPrintf(args, v...)
-	os.Exit(-1)
 }

--- a/cmd/iop/shared.go
+++ b/cmd/iop/shared.go
@@ -54,6 +54,7 @@ func configLogs(args *rootArgs) error {
 	if !args.logToStdErr {
 		opt.ErrorOutputPaths = []string{logFilePath}
 		opt.OutputPaths = []string{logFilePath}
+		defer log.Infof("Start running command: %v", os.Args)
 	}
 	return log.Configure(opt)
 }
@@ -68,65 +69,80 @@ func genManifests(args *rootArgs) (name.ManifestMap, error) {
 		overlayYAML = string(b)
 	}
 
+	overlayFilenameLog := args.inFilename
+	if overlayFilenameLog == "" {
+		overlayFilenameLog = "[Empty Filename]"
+	}
+
 	// Start with unmarshaling and validating the user CR (which is an overlay on the base profile).
 	overlayICPS := &v1alpha2.IstioControlPlaneSpec{}
 	if err := util.UnmarshalWithJSONPB(overlayYAML, overlayICPS); err != nil {
+		log.Errorf("Could not unmarshal the overlay YAML from file: %s", overlayFilenameLog)
 		return nil, err
 	}
 	if errs := validate.CheckIstioControlPlaneSpec(overlayICPS, false); len(errs) != 0 {
+		log.Errorf("Overlay spec failed validation against IstioControlPlaneSpec: \n%v\n", overlayICPS)
 		return nil, errs.ToError()
 	}
 
 	// Now read the base profile specified in the user spec. If nothing specified, use default.
 	baseYAML, err := helm.ReadValuesYAML(overlayICPS.Profile)
+
+	baseProfileName := overlayICPS.Profile
+	if baseProfileName == "" {
+		baseProfileName = "[Builtin Profile]"
+	}
+
 	if err != nil {
+		log.Errorf("Error reading YAML from profile: %s", baseProfileName)
 		return nil, err
 	}
 	// Unmarshal and validate the base CR.
 	baseICPS := &v1alpha2.IstioControlPlaneSpec{}
 	if err := util.UnmarshalWithJSONPB(baseYAML, baseICPS); err != nil {
+		log.Errorf("Could not unmarshal the base YAML from profile: %s", baseProfileName)
 		return nil, err
 	}
 	if errs := validate.CheckIstioControlPlaneSpec(baseICPS, true); len(errs) != 0 {
-		return nil, err
+		log.Errorf("Base spec failed validation against IstioControlPlaneSpec: \n%v\n", baseICPS)
+		return nil, errs.ToError()
 	}
 
 	mergedYAML, err := helm.OverlayYAML(baseYAML, overlayYAML)
 	if err != nil {
+		log.Errorf("Failed to merge base YAML (%s) and overlay YAML (%s)", baseProfileName, overlayFilenameLog)
 		return nil, err
 	}
 
 	// Now unmarshal and validate the combined base profile and user CR overlay.
-	mergedcps := &v1alpha2.IstioControlPlaneSpec{}
-	if err := util.UnmarshalWithJSONPB(mergedYAML, mergedcps); err != nil {
+	mergedICPS := &v1alpha2.IstioControlPlaneSpec{}
+	if err := util.UnmarshalWithJSONPB(mergedYAML, mergedICPS); err != nil {
+		log.Errorf("Could not unmarshal the merged YAML: \n%s\n", mergedYAML)
 		return nil, err
 	}
-	if errs := validate.CheckIstioControlPlaneSpec(mergedcps, true); len(errs) != 0 {
+	if errs := validate.CheckIstioControlPlaneSpec(mergedICPS, true); len(errs) != 0 {
+		log.Errorf("Merged spec failed validation against IstioControlPlaneSpec: \n%v\n", mergedICPS)
 		return nil, errs.ToError()
 	}
 
-	if yd := util.YAMLDiff(mergedYAML, util.ToYAMLWithJSONPB(mergedcps)); yd != "" {
-		return nil, fmt.Errorf("validated YAML differs from input: \n%s", yd)
+	if yd := util.YAMLDiff(mergedYAML, util.ToYAMLWithJSONPB(mergedICPS)); yd != "" {
+		return nil, fmt.Errorf("Merged YAML differs from merged spec: \n%s\n", yd)
 	}
 
+	log.Infof("Start running Istio control plane.")
+
 	// TODO: remove version hard coding.
-	cp := controlplane.NewIstioControlPlane(mergedcps, translate.Translators[version.NewMinorVersion(1, 2)])
+	cp := controlplane.NewIstioControlPlane(mergedICPS, translate.Translators[version.NewMinorVersion(1, 2)])
 	if err := cp.Run(); err != nil {
+		log.Errorf("Failed to run Istio control plane with spec: \n%v\n", mergedICPS)
 		return nil, err
 	}
 
 	manifests, errs := cp.RenderManifest()
-
-	return manifests, errs.ToError()
-}
-
-// TODO: this really doesn't belong here. Figure out if it's generally needed and possibly move to istio.io/pkg/log.
-func logAndPrintf(args *rootArgs, v ...interface{}) {
-	s := fmt.Sprintf(v[0].(string), v[1:]...)
-	if !args.logToStdErr {
-		fmt.Println(s)
+	if errs != nil {
+		return manifests, errs.ToError()
 	}
-	log.Infof(s)
+	return manifests, nil
 }
 
 func logAndFatalf(args *rootArgs, v ...interface{}) {

--- a/cmd/manager/server.go
+++ b/cmd/manager/server.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -28,12 +29,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 
-	"istio.io/pkg/ctrlz"
-	"istio.io/pkg/log"
-
 	"istio.io/operator/pkg/apis"
 	"istio.io/operator/pkg/controller"
 	"istio.io/operator/pkg/controller/istiocontrolplane"
+	"istio.io/pkg/ctrlz"
+	"istio.io/pkg/log"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -102,7 +102,7 @@ func run() {
 		log.Fatalf("Could not create a controller manager: %v", err)
 	}
 
-	log.Infof("Registering Components.")
+	log.Info("Registering Components.")
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
@@ -120,7 +120,7 @@ func run() {
 		log.Errorf("Could not create a service to expose the metrics port: %v", err.Error())
 	}
 
-	log.Infof("Starting the Cmd.")
+	log.Info("Starting the Cmd.")
 
 	// Start the Cmd
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {

--- a/cmd/manager/server.go
+++ b/cmd/manager/server.go
@@ -17,8 +17,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -30,11 +28,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 
+	"istio.io/pkg/ctrlz"
+	"istio.io/pkg/log"
+
 	"istio.io/operator/pkg/apis"
 	"istio.io/operator/pkg/controller"
 	"istio.io/operator/pkg/controller/istiocontrolplane"
-	"istio.io/pkg/ctrlz"
-	"istio.io/pkg/log"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -77,15 +76,13 @@ func serverCmd() *cobra.Command {
 func run() {
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
-		log.Errora(err, "Failed to get watch namespace")
-		os.Exit(1)
+		log.Fatalf("Failed to get watch namespace: %v", err)
 	}
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
-		log.Errora(err, "")
-		os.Exit(1)
+		log.Fatalf("Could not get apiserver config: %v", err)
 	}
 
 	ctx := context.TODO()
@@ -93,8 +90,7 @@ func run() {
 	// Become the leader before proceeding
 	err = leader.Become(ctx, "istio-operator-lock")
 	if err != nil {
-		log.Errora(err, "")
-		os.Exit(1)
+		log.Fatalf("Could not become the leader: %v", err)
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components
@@ -103,35 +99,31 @@ func run() {
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})
 	if err != nil {
-		log.Errora(err, "")
-		os.Exit(1)
+		log.Fatalf("Could not create a controller manager: %v", err)
 	}
 
-	log.Info("Registering Components.")
+	log.Infof("Registering Components.")
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Errora(err, "")
-		os.Exit(1)
+		log.Fatalf("Could not add manager scheme: %v", err)
 	}
 
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {
-		log.Errora(err, "")
-		os.Exit(1)
+		log.Fatalf("Could not add all controllers to operator manager: %v", err)
 	}
 
 	// Create Service object to expose the metrics port.
 	_, err = metrics.ExposeMetricsPort(ctx, metricsPort)
 	if err != nil {
-		log.Info(err.Error())
+		log.Errorf("Could not create a service to expose the metrics port: %v", err.Error())
 	}
 
-	log.Info("Starting the Cmd.")
+	log.Infof("Starting the Cmd.")
 
 	// Start the Cmd
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
-		log.Errora(err, "Manager exited non-zero")
-		os.Exit(1)
+		log.Fatalf("Manager exited non-zero: %v", err)
 	}
 }

--- a/cmd/vfsgen/vfsgen.go
+++ b/cmd/vfsgen/vfsgen.go
@@ -34,6 +34,6 @@ func main() {
 		//		BuildTags:    "deploy_build",
 		VariableName: "Assets",
 	}); err != nil {
-		log.Fatalln(err)
+		log.Fatalln("vfsgen failed to generate code: ", err)
 	}
 }

--- a/pkg/helm/fs_renderer.go
+++ b/pkg/helm/fs_renderer.go
@@ -62,7 +62,7 @@ func (h *FileTemplateRenderer) Run() error {
 	go func() {
 		for range chartChanged {
 			if err := h.loadChart(); err != nil {
-				log.Error(err.Error())
+				log.Errorf("Failed to load chart: %v", err.Error())
 			}
 		}
 	}()

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -68,7 +68,11 @@ func NewHelmRenderer(helmBaseDir, profile, componentName, namespace string) (Tem
 func ReadValuesYAML(profile string) (string, error) {
 	var err error
 	var globalValues string
-	log.Infof("ReadValuesYAML for profile name: %s", profile)
+	if profile == "" {
+		log.Infof("ReadValuesYAML for profile name: [Empty]")
+	} else {
+		log.Infof("ReadValuesYAML for profile name: %s", profile)
+	}
 
 	// Get global values from profile.
 	switch {

--- a/pkg/helm/vfs_renderer.go
+++ b/pkg/helm/vfs_renderer.go
@@ -125,7 +125,7 @@ func (h *VFSRenderer) loadChart() error {
 			Data: b,
 		}
 		bfs = append(bfs, bf)
-		log.Infof("loaded %s", bf.Name)
+		log.Infof("Chart loaded: %s", bf.Name)
 	}
 
 	h.chart, err = chartutil.LoadFiles(bfs)

--- a/pkg/kubectlcmd/client.go
+++ b/pkg/kubectlcmd/client.go
@@ -49,7 +49,7 @@ func (console) Run(c *exec.Cmd) error {
 // Apply runs the kubectl apply with the provided manifest argument
 func (c *Client) Apply(dryRun, verbose bool, namespace string, manifest string, extraArgs ...string) (string, string, error) {
 	if strings.TrimSpace(manifest) == "" {
-		log.Info("Empty manifest, not applying.")
+		log.Infof("Empty manifest, not applying.")
 		return "", "", nil
 	}
 

--- a/pkg/manifest/installer.go
+++ b/pkg/manifest/installer.go
@@ -165,7 +165,7 @@ func renderRecursive(manifests name.ManifestMap, installTree componentTree, outp
 func ApplyAll(manifests name.ManifestMap, version version.Version, dryRun, verbose bool) (*CompositeOutput, error) {
 	logAndPrint("Applying manifests for these components:")
 	for c := range manifests {
-		log.Infof("- %s", c)
+		logAndPrint("- %s", c)
 	}
 	logAndPrint("Component dependencies tree: \n%s", installTreeString())
 	if err := initK8SRestClient(); err != nil {

--- a/pkg/object/objects.go
+++ b/pkg/object/objects.go
@@ -244,7 +244,7 @@ func ParseK8sObjectsFromYAMLManifest(manifest string) (K8sObjects, error) {
 		}
 		o, err := ParseYAMLToK8sObject([]byte(yaml))
 		if err != nil {
-			log.Info(err.Error())
+			log.Errorf("Failed to parse YAML to a k8s object: %v", err.Error())
 			continue
 		}
 

--- a/pkg/translate/translate.go
+++ b/pkg/translate/translate.go
@@ -301,12 +301,12 @@ func overlayK8s(baseYAML, overlayYAML []byte, path util.Path) ([]byte, error) {
 	base, overlayMap := make(map[string]interface{}), make(map[string]interface{})
 	var overlay interface{} = overlayMap
 	if err := yaml.Unmarshal(baseYAML, &base); err != nil {
-		return nil, fmt.Errorf("Failed to unmarshal in overlayK8s: %s for baseYAML:\n%s", err, baseYAML)
+		return nil, fmt.Errorf("failed to unmarshal in overlayK8s: %s for baseYAML:\n%s", err, baseYAML)
 	}
 	if err := yaml.Unmarshal(overlayYAML, &overlayMap); err != nil {
 		// May be a scalar type, try to unmarshal into interface instead.
 		if err := yaml.Unmarshal(overlayYAML, &overlay); err != nil {
-			return nil, fmt.Errorf("Failed to unmarshal in overlayK8s: %s for overlayYAML:\n%s", err, overlayYAML)
+			return nil, fmt.Errorf("failed to unmarshal in overlayK8s: %s for overlayYAML:\n%s", err, overlayYAML)
 		}
 	}
 	if err := tpath.WriteNode(base, path, overlay); err != nil {

--- a/pkg/translate/translate.go
+++ b/pkg/translate/translate.go
@@ -301,12 +301,12 @@ func overlayK8s(baseYAML, overlayYAML []byte, path util.Path) ([]byte, error) {
 	base, overlayMap := make(map[string]interface{}), make(map[string]interface{})
 	var overlay interface{} = overlayMap
 	if err := yaml.Unmarshal(baseYAML, &base); err != nil {
-		return nil, fmt.Errorf("overlayK8s: %s for baseYAML:\n%s", err, baseYAML)
+		return nil, fmt.Errorf("Failed to unmarshal in overlayK8s: %s for baseYAML:\n%s", err, baseYAML)
 	}
 	if err := yaml.Unmarshal(overlayYAML, &overlayMap); err != nil {
 		// May be a scalar type, try to unmarshal into interface instead.
 		if err := yaml.Unmarshal(overlayYAML, &overlay); err != nil {
-			return nil, fmt.Errorf("overlayK8s: %s for overlayYAML:\n%s", err, overlayYAML)
+			return nil, fmt.Errorf("Failed to unmarshal in overlayK8s: %s for overlayYAML:\n%s", err, overlayYAML)
 		}
 	}
 	if err := tpath.WriteNode(base, path, overlay); err != nil {
@@ -518,13 +518,13 @@ func renderFeatureComponentPathTemplate(tmpl string, featureName name.FeatureNam
 	}
 	t, err := template.New("").Parse(tmpl)
 	if err != nil {
-		log.Error(err.Error())
+		log.Errorf("Failed to create template object, Error: %v. Template string: \n%s\n", err.Error(), tmpl)
 		return err.Error()
 	}
 	buf := new(bytes.Buffer)
 	err = t.Execute(buf, ts)
 	if err != nil {
-		log.Error(err.Error())
+		log.Errorf("Failed to execute template: %v", err.Error())
 		return err.Error()
 	}
 	return buf.String()

--- a/pkg/validate/common.go
+++ b/pkg/validate/common.go
@@ -93,7 +93,7 @@ func validateWithRegex(path util.Path, val interface{}, r *regexp.Regexp) (errs 
 		errs = util.AppendErr(errs, fmt.Errorf("path %s has bad type %T, want string", path, val))
 
 	case len(r.FindString(val.(string))) != len(val.(string)):
-		errs = util.AppendErr(errs, fmt.Errorf("invalid value %s:%s", path, val))
+		errs = util.AppendErr(errs, fmt.Errorf("invalid value %s: %s", path, val))
 	}
 
 	printError(errs.ToError())

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -22,7 +22,6 @@ import (
 
 	"istio.io/operator/pkg/apis/istio/v1alpha2"
 	"istio.io/operator/pkg/util"
-	"istio.io/pkg/log"
 )
 
 var (
@@ -44,7 +43,6 @@ var (
 // CheckIstioControlPlaneSpec validates the values in the given Installer spec, using the field map defaultValidations to
 // call the appropriate validation function.
 func CheckIstioControlPlaneSpec(is *v1alpha2.IstioControlPlaneSpec, checkRequired bool) util.Errors {
-	log.Infof("Validating IstioControlPlaneSpec")
 	return validate(defaultValidations, is, nil, checkRequired)
 }
 
@@ -154,7 +152,7 @@ func validateInstallPackagePath(path util.Path, val interface{}) util.Errors {
 	}
 
 	if _, err := url.ParseRequestURI(val.(string)); err != nil {
-		return util.NewErrs(fmt.Errorf("invalid value %s:%s", path, valStr))
+		return util.NewErrs(fmt.Errorf("invalid value %s: %s", path, valStr))
 	}
 
 	validPrefixes := []string{util.LocalFilePrefix}

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -241,14 +241,14 @@ trafficManagement:
 			yamlStr: `
 hub: ?illegal-tag!
 `,
-			wantErrs: makeErrors([]string{`invalid value Hub:?illegal-tag!`}),
+			wantErrs: makeErrors([]string{`invalid value Hub: ?illegal-tag!`}),
 		},
 		{
 			desc: "BadHub",
 			yamlStr: `
 hub: docker.io:tag/istio
 `,
-			wantErrs: makeErrors([]string{`invalid value Hub:docker.io:tag/istio`}),
+			wantErrs: makeErrors([]string{`invalid value Hub: docker.io:tag/istio`}),
 		},
 		{
 			desc: "GoodURL",
@@ -261,7 +261,7 @@ customPackagePath: file:///local/file/path
 			yamlStr: `
 customPackagePath: bad_schema://local/file/path
 `,
-			wantErrs: makeErrors([]string{`invalid value CustomPackagePath:bad_schema://local/file/path`}),
+			wantErrs: makeErrors([]string{`invalid value CustomPackagePath: bad_schema://local/file/path`}),
 		},
 	}
 


### PR DESCRIPTION
Add error logs for various scenarios. Update exsting log messages and log level. When choose log-to-file, also echo input command into log.

Resolve: istio/istio#15225

Sample logs for the scenarios in istio/istio#15225

1. Bad file path to CR file
taohe@taohe:~/istio.io/operator$ iop manifest --filename data/profiles/nonexist.yaml --logtostderr
2019-07-18T20:24:10.855308Z	fatal	Could not open input file: open data/profiles/nonexist.yaml: no such file or directory

2. Bad yaml in user CR
taohe@taohe:~/istio.io/operator$ iop manifest --filename data/profiles/bad_yaml.yaml --logtostderr
2019-07-18T20:28:57.492712Z	error	Could not unmarshal the overlay YAML from file: data/profiles/bad_yaml.yaml
2019-07-18T20:28:57.492737Z	fatal	Could not generate manifests: yaml: line 5: did not find expected '-' indicator

3. Unknown field in yaml
taohe@taohe:~/istio.io/operator$ iop manifest --logtostderr --filename data/profiles/unknown_fields.yaml
2019-07-18T20:30:41.395378Z	error	Could not unmarshal the overlay YAML from file: data/profiles/unknown_fields.yaml
2019-07-18T20:30:41.395423Z	fatal	Could not generate manifests: unknown field "telemetry_unknown" in v1alpha2.IstioControlPlaneSpec

4. Bad value for type constrained field
taohe@taohe:~/istio.io/operator$ iop manifest --logtostderr --filename data/profiles/bad_type.yaml
2019-07-18T20:32:21.451568Z	error	Could not unmarshal the overlay YAML from file: data/profiles/bad_type.yaml
2019-07-18T20:32:21.451620Z	fatal	Could not generate manifests: json: cannot unmarshal string into Go value of type bool

5. bad value in validated field Hub
taohe@taohe:~/istio.io/operator$ iop manifest --logtostderr --filename data/profiles/bad_validated_hub.yaml
2019-07-18T20:59:47.070318Z	error	Overlay spec failed validation against IstioControlPlaneSpec: 
2019-07-18T20:59:47.070388Z	fatal	Could not generate manifests: invalid value Hub: docker.io!!!/istio

6. bad value in validated field DefaultNamespacePrefix
taohe@taohe:~/istio.io/operator$ iop manifest --logtostderr --filename data/profiles/bad_validated_version.yaml
2019-07-18T21:11:51.476805Z	error	Overlay spec failed validation against IstioControlPlaneSpec: 
2019-07-18T21:11:51.476862Z	fatal	Could not generate manifests: invalid value Tag: .1.1.4

7. bad value in validated field Overlay
taohe@taohe:~/istio.io/operator$ iop manifest --logtostderr --filename data/profiles/bad_validated_ns_prefix.yaml
2019-07-18T21:11:51.476805Z	error	Overlay spec failed validation against IstioControlPlaneSpec: 
2019-07-18T21:19:30.849275Z	fatal	Could not generate manifests: invalid value DefaultNamespacePrefix: ?istio-system