### PR TITLE
Adding iops.log to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ bin/protoc-min-version*
 bin/protoc-gen-docs*
 *.orig
 build/_output/
-
+iop.log


### PR DESCRIPTION
While trying out the operator for the first time, I noticed that this `iops.log` was generated. Adding this to the .gitignore.

Signed-off-by: Jason Clark <jason.clark@ibm.com>