### PR TITLE
Makefile: specify dependencies for vfsgen. Add iop target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+export GO111MODULE=on
+
 gen_img := gcr.io/istio-testing/protoc:2019-03-29
 pwd := $(shell pwd)
 mount_dir := /src
@@ -42,6 +44,9 @@ gogofast_plugin := $(gogofast_plugin_prefix)$(gogo_mapping):$(out_path)
 api_path := pkg/apis/istio/v1alpha2
 api_protos := $(shell find $(api_path) -type f -name '*.proto' | sort)
 api_pb_gos := $(api_protos:.proto=.pb.go)
+
+.PHONY: default
+default: iop
 
 generate-api-go: $(api_pb_gos)
 	patch pkg/apis/istio/v1alpha2/istiocontrolplane_types.pb.go < pkg/apis/istio/v1alpha2/fixup_go_structs.patch
@@ -104,5 +109,9 @@ gen_patch_iscp:
 gen_patch_values:
 	diff -u pkg/apis/istio/v1alpha2/values/values_types.pb.go.orig pkg/apis/istio/v1alpha2/values/values_types.pb.go > pkg/apis/istio/v1alpha2/values/fix_values_structs.patch || true
 
-vfsgen:
+vfsgen: data/
+	go get github.com/shurcooL/vfsgen
 	go generate ./cmd/iop.go
+
+iop: vfsgen
+	go build -o ${GOPATH}/bin/iop ./cmd/iop.go

--- a/README.md
+++ b/README.md
@@ -79,10 +79,9 @@ The quick start describes how to install and use the operator `iop` CLI command.
 ### Installation
 
 ```bash
-export GO111MODULE=on # for pre-1.13 Go versions
 git clone https://github.com/istio/operator.git
 cd operator
-go build -o $GOPATH/bin/iop ./cmd/iop.go
+make iop
 ```
 
 ### Flags


### PR DESCRIPTION
Specify dependencies for vfsgen. Add iop target. Also update the Readme.

Having this PR out to get more ideas of how to improve the Makefile.

Resolve: https://github.com/istio/istio/issues/15237