### PR TITLE
Add validation for IP ranges in operator's validate.go

### DIFF
--- a/pkg/name/name.go
+++ b/pkg/name/name.go
@@ -198,7 +198,7 @@ func getFromStructPath(node interface{}, path util.Path) (interface{}, bool, err
 		}
 	case reflect.Ptr:
 		structElems = reflect.ValueOf(node).Elem()
-		if reflect.TypeOf(structElems).Kind() != reflect.Struct {
+		if !util.IsStruct(structElems) {
 			return nil, false, fmt.Errorf("getFromStructPath path %s, expected struct ptr, got %T", path, node)
 		}
 	default:

--- a/pkg/util/reflect.go
+++ b/pkg/util/reflect.go
@@ -47,6 +47,10 @@ func IsSlice(value interface{}) bool {
 	return reflect.TypeOf(value).Kind() == reflect.Slice
 }
 
+func IsStruct(value interface{}) bool {
+	return reflect.TypeOf(value).Kind() == reflect.Struct
+}
+
 // IsSlicePtr reports whether v is a slice ptr type.
 func IsSlicePtr(v interface{}) bool {
 	t := reflect.TypeOf(v)

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -50,15 +50,15 @@ func validate(validations map[string]ValidatorFunc, structPtr interface{}, path 
 	if structPtr == nil {
 		return nil
 	}
-	if reflect.TypeOf(structPtr).Kind() == reflect.Struct {
+	if util.IsStruct(structPtr) {
 		scope.Debugf("validate path %s, skipping struct type %T", path, structPtr)
 		return nil
 	}
-	if reflect.TypeOf(structPtr).Kind() != reflect.Ptr {
+	if !util.IsPtr(structPtr) {
 		return util.NewErrs(fmt.Errorf("validate path %s, value: %v, expected ptr, got %T", path, structPtr, structPtr))
 	}
 	structElems := reflect.ValueOf(structPtr).Elem()
-	if reflect.TypeOf(structElems).Kind() != reflect.Struct {
+	if !util.IsStruct(structElems) {
 		return util.NewErrs(fmt.Errorf("validate path %s, value: %v, expected struct, got %T", path, structElems, structElems))
 	}
 

--- a/pkg/validate/validate_values.go
+++ b/pkg/validate/validate_values.go
@@ -21,8 +21,8 @@ import (
 var (
 	// defaultValidations maps a data path to a validation function.
 	defaultValuesValidations = map[string]ValidatorFunc{
-		"global.proxy.includeIpRanges":     validateStringList(validateCIDR),
-		"global.proxy.excludeIpRanges":     validateStringList(validateCIDR),
+		"global.proxy.includeIpRanges":     validateIPRangesOrStar,
+		"global.proxy.excludeIpRanges":     validateIPRangesOrStar,
 		"global.proxy.includeInboundPorts": validateStringList(validatePortNumberString),
 		"global.proxy.excludeInboundPorts": validateStringList(validatePortNumberString),
 	}

--- a/pkg/validate/validate_values_test.go
+++ b/pkg/validate/validate_values_test.go
@@ -33,6 +33,15 @@ func TestValidateValues(t *testing.T) {
 			desc: "nil success",
 		},
 		{
+			desc: "StarIPRange",
+			yamlStr: `
+global:
+  proxy:
+    includeIpRanges: "*"
+    excludeIpRanges: "*"
+`,
+		},
+		{
 			desc: "ProxyConfig",
 			yamlStr: `
 global:
@@ -73,6 +82,15 @@ global:
 `,
 			wantErrs: makeErrors([]string{`global.proxy.includeIpRanges invalid CIDR address: 1.2.3/16`,
 				`global.proxy.includeIpRanges invalid CIDR address: 1.2.3.x/16`}),
+		},
+		{
+			desc: "BadIPWithStar",
+			yamlStr: `
+global:
+  proxy:
+    includeIpRanges: "*,1.1.0.0/16,2.2.0.0/16"
+`,
+			wantErrs: makeErrors([]string{`global.proxy.includeIpRanges invalid CIDR address: *`}),
 		},
 		{
 			desc: "BadPortRange",


### PR DESCRIPTION
ValidateCIDR is implemented in common.go but not used by any non-test code.
Now use ValidateCIDR to validate  ip ranges in profiles.

Resolve: https://github.com/istio/istio/issues/15683

