### PR TITLE
fix unknown field for unmarshaling.

### DIFF
--- a/data/profiles/default.yaml
+++ b/data/profiles/default.yaml
@@ -3,7 +3,7 @@ kind: IstioControlPlane
 spec:
   hub: docker.io/istio
   tag: 1.1.4
-  namespacePrefix: istio-system
+  defaultNamespace: istio-system
 
   # Traffic management feature
   trafficManagement:

--- a/data/profiles/demo-auth.yaml
+++ b/data/profiles/demo-auth.yaml
@@ -3,7 +3,7 @@ kind: IstioControlPlane
 spec:
   hub: docker.io/istio
   tag: 1.1.4
-  namespacePrefix: istio-system
+  defaultNamespace: istio-system
 
   # Traffic management feature
   trafficManagement:

--- a/data/profiles/demo.yaml
+++ b/data/profiles/demo.yaml
@@ -3,7 +3,7 @@ kind: IstioControlPlane
 spec:
   hub: docker.io/istio
   tag: 1.1.4
-  namespacePrefix: istio-system
+  defaultNamespace: istio-system
 
   # Traffic management feature
   trafficManagement:

--- a/data/profiles/minimal.yaml
+++ b/data/profiles/minimal.yaml
@@ -3,7 +3,7 @@ kind: IstioControlPlane
 spec:
   hub: docker.io/istio
   tag: 1.1.4
-  namespacePrefix: istio-system
+  defaultNamespace: istio-system
 
   # Traffic management feature
   trafficManagement:

--- a/data/profiles/sds.yaml
+++ b/data/profiles/sds.yaml
@@ -3,7 +3,7 @@ kind: IstioControlPlane
 spec:
   hub: docker.io/istio
   tag: 1.1.4
-  namespacePrefix: istio-system
+  defaultNamespace: istio-system
 
   # Traffic management feature
   trafficManagement:


### PR DESCRIPTION
Resolve: https://github.com/istio/istio/issues/15874

Since we updated `defaultNamespacePrefix` to `defaultNamespace`, we should update the corresponding field in profiles, see: https://github.com/istio/operator/blob/master/pkg/apis/istio/v1alpha2/istiocontrolplane_types.proto#L159