### PR TITLE
Fix mac building

### DIFF
--- a/Makefile.container.mk
+++ b/Makefile.container.mk
@@ -24,7 +24,6 @@ fmt:
 
 # make target dependencies
 vfsgen: data/
-	go get github.com/shurcooL/vfsgen
 	go generate ./cmd/mesh.go
 
 ########################

--- a/cmd/mesh.go
+++ b/cmd/mesh.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:generate go run ./vfsgen/vfsgen.go
+//go:generate
 package main
 
 import (


### PR DESCRIPTION
A couple notes:

Any binary tool that needs to be used should first be installed in
the istio/tools/docker/build-tools/Dockerfile.  Any go generate
should not compile, as this won't work cross platform.