### PR TITLE
This is unneeded and probably incorrect.

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -1,8 +1,6 @@
 # make targets
 .PHONY: lint test_with_coverage mandiff build fmt vfsgen
 
-GOBIN = /work/out/bin
-
 lint:
 	@scripts/check_license.sh
 	@golangci-lint run -j 8 -v ./...


### PR DESCRIPTION
All common makefile work should go in Makefile, not in
Makefile.core.mk files.