### PR TITLE
set the default target of make to mesh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export GO111MODULE=on
 RUN =
 
 # Set the environment variable BUILD_WITH_CONTAINER to use a container

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -63,6 +63,8 @@ api_protos := $(shell find $(api_path) -type f -name '*.proto' | sort)
 api_pb_gos := $(api_protos:.proto=.pb.go)
 
 
+.PHONY: default
+.DEFAULT_GOAL :=
 default: mesh
 
 generate-api-go: $(api_pb_gos)


### PR DESCRIPTION
export GO111MODULE=on, so we can run `make` command when this repo is in GOPATH.