### PR TITLE
Fix reverse translation issue

### DIFF
--- a/cmd/mesh/manifest-migrate.go
+++ b/cmd/mesh/manifest-migrate.go
@@ -17,12 +17,10 @@ package mesh
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
-	"strings"
-
 	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/spf13/cobra"
+	"path/filepath"
 
 	"istio.io/operator/pkg/kubectlcmd"
 	"istio.io/operator/pkg/translate"
@@ -59,18 +57,21 @@ func manifestMigrateCmd(rootArgs *rootArgs, mmArgs *manifestMigrateArgs) *cobra.
 }
 
 func valueFileFilter(path string) bool {
-	return filepath.Ext(path) == YAMLSuffix && strings.HasPrefix(filepath.Base(path), "values")
+	return filepath.Base(path) == "values.yaml"
 }
 
 // migrateFromFiles handles migration for local values.yaml files
 func migrateFromFiles(rootArgs *rootArgs, args []string) {
 	checkLogsOrExit(rootArgs)
-
-	logAndPrintf(rootArgs, "translating input values.yaml file at: %s to new API", args[0])
 	value, err := util.ReadFiles(args[0], valueFileFilter)
 	if err != nil {
 		logAndFatalf(rootArgs, err.Error())
 	}
+	if value == "" {
+		logAndPrintf(rootArgs, "no valid value.yaml file specified")
+		return
+	}
+	logAndPrintf(rootArgs, "translating input values.yaml file at: %s to new API", args[0])
 	translateFunc(rootArgs, []byte(value))
 }
 

--- a/cmd/mesh/manifest-migrate.go
+++ b/cmd/mesh/manifest-migrate.go
@@ -18,12 +18,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/spf13/cobra"
 
-	"istio.io/operator/pkg/apis/istio/v1alpha2"
 	"istio.io/operator/pkg/kubectlcmd"
 	"istio.io/operator/pkg/translate"
 	"istio.io/operator/pkg/util"
@@ -59,7 +59,7 @@ func manifestMigrateCmd(rootArgs *rootArgs, mmArgs *manifestMigrateArgs) *cobra.
 }
 
 func valueFileFilter(path string) bool {
-	return filepath.Base(path) == "values.yaml"
+	return filepath.Ext(path) == YAMLSuffix && strings.HasPrefix(filepath.Base(path), "values")
 }
 
 // migrateFromFiles handles migration for local values.yaml files
@@ -81,13 +81,7 @@ func translateFunc(rootArgs *rootArgs, values []byte) {
 		logAndFatalf(rootArgs, "error creating values.yaml translator: %s", err.Error())
 	}
 
-	valueStruct := v1alpha2.Values{}
-	err = yaml.Unmarshal(values, &valueStruct)
-	if err != nil {
-		logAndFatalf(rootArgs, "error unmarshalling values.yaml into value struct : %s", err.Error())
-	}
-
-	isCPSpec, err := ts.TranslateFromValueToSpec(&valueStruct)
+	isCPSpec, err := ts.TranslateFromValueToSpec(values)
 	if err != nil {
 		logAndFatalf(rootArgs, "error translating values.yaml: %s", err.Error())
 	}

--- a/cmd/mesh/manifest-migrate.go
+++ b/cmd/mesh/manifest-migrate.go
@@ -17,10 +17,11 @@ package mesh
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
+
 	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/spf13/cobra"
-	"path/filepath"
 
 	"istio.io/operator/pkg/kubectlcmd"
 	"istio.io/operator/pkg/translate"

--- a/pkg/translate/translate_value.go
+++ b/pkg/translate/translate_value.go
@@ -432,7 +432,7 @@ func (t *ReverseTranslator) translateK8sTree(valueTree map[string]interface{},
 	return nil
 }
 
-// translateRemainingPaths translates remaining paths that are not availing in existing mappings.
+// translateRemainingPaths translates remaining paths that are not available in existing mappings.
 func (t *ReverseTranslator) translateRemainingPaths(valueTree map[string]interface{},
 	cpSpecTree map[string]interface{}, path util.Path) error {
 	for key, val := range valueTree {

--- a/pkg/translate/translate_value_test.go
+++ b/pkg/translate/translate_value_test.go
@@ -66,7 +66,7 @@ global:
   tag: 1.2.3
   telemetryNamespace: istio-telemetry
   proxy:
-    ReadinessInitialDelaySeconds: 2
+    readinessInitialDelaySeconds: 2
 mixer:
   policy:
     enabled: true
@@ -170,7 +170,7 @@ autoInjection:
 		{
 			desc: "All Enabled",
 			valueYAML: `
-certManager:
+certmanager:
   enabled: true
 galley:
   enabled: true
@@ -187,7 +187,7 @@ mixer:
     enabled: true
 pilot:
   enabled: true
-nodeAgent:
+nodeagent:
   enabled: true
 gateways:
   enabled: true
@@ -358,7 +358,7 @@ autoInjection:
 				t.Fatalf("unmarshal(%s): got error %s", tt.desc, err)
 			}
 			scope.Debugf("value struct: \n%s\n", pretty.Sprint(valueStruct))
-			got, err := tr.TranslateFromValueToSpec(&valueStruct)
+			got, err := tr.TranslateFromValueToSpec([]byte(tt.valueYAML))
 			if gotErr, wantErr := errToString(err), tt.wantErr; gotErr != wantErr {
 				t.Errorf("ValuesToProto(%s)(%v): gotErr:%s, wantErr:%s", tt.desc, tt.valueYAML, gotErr, wantErr)
 			}

--- a/pkg/translate/translate_value_test.go
+++ b/pkg/translate/translate_value_test.go
@@ -51,6 +51,8 @@ pilot:
   autoscaleEnabled: true
   autoscaleMax: 3
   autoscaleMin: 1
+  cpu:
+    targetAverageUtilization: 80
   traceSampling: 1.0
   image: pilot
   env:
@@ -144,7 +146,15 @@ trafficManagement:
          hpaSpec:
             maxReplicas: 3
             minReplicas: 1
-            scaleTargetRef: {}
+            scaleTargetRef:
+               apiVersion: apps/v1
+               kind: Deployment
+               name: istio-pilot
+            metrics:
+             - resource:
+                 name: cpu
+                 targetAverageUtilization: 80
+               type: Resource
          nodeSelector:
             beta.kubernetes.io/os: linux
          resources:


### PR DESCRIPTION
1. Minor bug fix
2. Actually we don't need to unmarshall input values.yaml to values.types struct first and then marshall, which would lose some settings that don't have translation mappings. We can just take the input values.yaml value and do the reverse translation so that all untranslated path can be populated to common.values of different components.