### PR TITLE
Fix flag not taking effect in manifest generate.

### DIFF
--- a/cmd/mesh/manifest.go
+++ b/cmd/mesh/manifest.go
@@ -151,7 +151,7 @@ func makeTreeFromSetList(setOverlay []string) (string, error) {
 			return "", fmt.Errorf("bad argument %s: expect format key=value", kv)
 		}
 		k := kvv[0]
-		v := kvv[1]
+		v := util.ParseValue(kvv[1])
 		if err := tpath.WriteNode(tree, util.PathFromString(k), v); err != nil {
 			return "", err
 		}

--- a/pkg/translate/translate.go
+++ b/pkg/translate/translate.go
@@ -267,7 +267,7 @@ var (
 					ResourceName:         "istio-citadel",
 					ContainerName:        "citadel",
 					HelmSubdir:           "security/citadel",
-					ToHelmValuesTreeRoot: "citadel",
+					ToHelmValuesTreeRoot: "security",
 				},
 				name.NodeAgentComponentName: {
 					ResourceName:         "istio-nodeagent",

--- a/pkg/translate/translate_test.go
+++ b/pkg/translate/translate_test.go
@@ -40,7 +40,7 @@ defaultNamespace: istio-system
 certmanager:
   enabled: false
   namespace: istio-system
-citadel:
+security:
   enabled: false
   namespace: istio-system
 galley:
@@ -93,7 +93,7 @@ defaultNamespace: istio-system
 certmanager:
   enabled: false
   namespace: istio-system
-citadel:
+security:
   enabled: false
   namespace: istio-system
 galley:
@@ -149,7 +149,7 @@ security:
 certmanager:
   enabled: true
   namespace: istio-system
-citadel:
+security:
   enabled: true
   namespace: istio-system
 galley:

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -94,4 +95,19 @@ func ReadFiles(dirName string, filter FileFilter) (string, error) {
 		}
 	}
 	return sb.String(), nil
+}
+
+// ParseValue parses string into a value
+func ParseValue(valueStr string) interface{} {
+	var value interface{}
+	if v, err := strconv.Atoi(valueStr); err == nil {
+		value = v
+	} else if v, err := strconv.ParseFloat(valueStr, 64); err == nil {
+		value = v
+	} else if v, err := strconv.ParseBool(valueStr); err == nil {
+		value = v
+	} else {
+		value = valueStr
+	}
+	return value
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,95 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+)
+
+func TestParseValue(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   string
+		want interface{}
+	}{
+		{
+			desc: "empty",
+			in:   "",
+			want: "",
+		},
+		{
+			desc: "true",
+			in:   "true",
+			want: true,
+		},
+		{
+			desc: "false",
+			in:   "false",
+			want: false,
+		},
+		{
+			desc: "numeric-one",
+			in:   "1",
+			want: 1,
+		},
+		{
+			desc: "numeric-zero",
+			in:   "0",
+			want: 0,
+		},
+		{
+			desc: "numeric-large",
+			in:   "12345678",
+			want: 12345678,
+		},
+		{
+			desc: "numeric-negative",
+			in:   "-12345678",
+			want: -12345678,
+		},
+		{
+			desc: "float",
+			in:   "1.23456",
+			want: 1.23456,
+		},
+		{
+			desc: "float-zero",
+			in:   "0.00",
+			want: 0.00,
+		},
+		{
+			desc: "float-negative",
+			in:   "-6.54321",
+			want: -6.54321,
+		},
+		{
+			desc: "string",
+			in:   "foobar",
+			want: "foobar",
+		},
+		{
+			desc: "string-number-prefix",
+			in:   "123foobar",
+			want: "123foobar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got, want := ParseValue(tt.in), tt.want; !(got == want) {
+				t.Errorf("%s: got:%v, want:%v", tt.desc, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix issue https://github.com/istio/istio/issues/16305:
--set option doesn't always override the values in the specified input: default.yaml is a copy of the built-in default profile spec.

$ ~go/bin/mesh manifest generate -f default.yaml -s security.components.citadel.common.values.selfSigned=false | grep self-signed-ca
- --self-signed-ca=true


Root cause:
1. TranslateHelmValues() is not translating citadel configs into root ["security"](https://istio.io/docs/reference/config/installation-options/#security-options) (incorrectly set to "citadel"), so it will not overwrite values from profile/set-value to the security chart.
2. The args passed from CLI is always typed to string rather than bool/int/float. When we marshal it into yaml or ICPS, the type is still mistakenly set to string. + The Helm Render engine will ignore it if the type does not match the corresponding path in chart.


