### PR TITLE
Stabilizing manifest generation to create text diffable output

### DIFF
--- a/cmd/mesh/manifest-generate_test.go
+++ b/cmd/mesh/manifest-generate_test.go
@@ -93,6 +93,26 @@ func TestManifestGenerateTelemetry(t *testing.T) {
 	})
 }
 
+func TestManifestGenerateOrdered(t *testing.T) {
+	// Since this is testing the special case of stable YAML output order, it
+	// does not use the established test group pattern
+	t.Run("stable_manifest", func(t *testing.T) {
+		inPath := filepath.Join(testDataDir, "input", "all_on.yaml")
+		got1, err := runManifestGenerate(inPath, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		got2, err := runManifestGenerate(inPath, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got1 != got2 {
+			t.Errorf("stable_manifest: Manifest generation is not producing stable text output.")
+		}
+	})
+}
+
 func runTestGroup(t *testing.T, tests testGroup) {
 	testDataDir = filepath.Join(repoRootDir, "cmd/mesh/testdata/manifest-generate")
 	for _, tt := range tests {

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"strings"
+	"sort"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/ghodss/yaml"
@@ -112,8 +113,16 @@ func renderChart(namespace, values string, chrt *chart.Chart) (string, error) {
 		return "", err
 	}
 
+	// Create sorted array of keys to iterate over, to stabilize the order of the rendered templates
+	keys := make([]string, 0, len(files))
+	for k := range files {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	var sb strings.Builder
-	for _, f := range files {
+	for i := 0; i < len(keys); i++ {
+		f := files[keys[i]]
 		// add yaml separator if the rendered file doesn't have one at the end
 		if !strings.HasSuffix(strings.TrimSpace(f)+"\n", YAMLSeparator) {
 			f += YAMLSeparator

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 	"sort"
+	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/ghodss/yaml"


### PR DESCRIPTION
This PR stabilizes the output order of the `mesh generate` family of commands, which will cause them to produce text diffable output (e.g. you can now run `mesh generate > test.yaml`, `mesh generate > test2.yaml`, and then `diff test.yaml test2.yaml` and get a zero diff).

This fix is to close https://github.com/istio/istio/issues/15273, which I believe was created before the operator was forked into its own repository.