### PR TITLE
Usage messages, grammar, and manifest apply --yes opt

### DIFF
--- a/cmd/mesh/manifest-apply.go
+++ b/cmd/mesh/manifest-apply.go
@@ -49,7 +49,7 @@ func addManifestApplyFlags(cmd *cobra.Command, args *manifestApplyArgs) {
 	cmd.PersistentFlags().StringVarP(&args.inFilename, "filename", "f", "", filenameFlagHelpStr)
 	cmd.PersistentFlags().StringVarP(&args.kubeConfigPath, "kubeconfig", "c", "", "Path to kube config")
 	cmd.PersistentFlags().StringVar(&args.context, "context", "", "The name of the kubeconfig context to use")
-	cmd.PersistentFlags().BoolVar(&args.yes, "yes", false, "Do not ask for confirmation")
+	cmd.PersistentFlags().BoolVarP(&args.yes, "yes", "y", false, "Do not ask for confirmation")
 	cmd.PersistentFlags().DurationVar(&args.readinessTimeout, "readiness-timeout", 300*time.Second, "Maximum seconds to wait for all Istio resources to be ready."+
 		" The --wait flag must be set for this flag to apply")
 	cmd.PersistentFlags().BoolVarP(&args.wait, "wait", "w", false, "Wait, if set will wait until all Pods, Services, and minimum number of Pods "+

--- a/cmd/mesh/manifest-apply.go
+++ b/cmd/mesh/manifest-apply.go
@@ -37,11 +37,11 @@ type manifestApplyArgs struct {
 	readinessTimeout time.Duration
 	// wait is flag that indicates whether to wait resources ready before exiting.
 	wait bool
+	// yes means don't ask for confirmation (asking for confirmation not implemented)
+	yes bool
 	// set is a string with element format "path=value" where path is an IstioControlPlane path and the value is a
 	// value to set the node at that path to.
 	set []string
-	// yes means don't ask for confirmation (asking for confirmation not implemented)
-	yes bool
 }
 
 func addManifestApplyFlags(cmd *cobra.Command, args *manifestApplyArgs) {

--- a/cmd/mesh/manifest-apply.go
+++ b/cmd/mesh/manifest-apply.go
@@ -46,13 +46,13 @@ type manifestApplyArgs struct {
 
 func addManifestApplyFlags(cmd *cobra.Command, args *manifestApplyArgs) {
 	cmd.PersistentFlags().StringVarP(&args.inFilename, "filename", "f", "", filenameFlagHelpStr)
-	cmd.PersistentFlags().StringVarP(&args.kubeConfigPath, "kubeconfig", "c", "", "Path to kube config.")
+	cmd.PersistentFlags().StringVarP(&args.kubeConfigPath, "kubeconfig", "c", "", "Path to kube config")
 	cmd.PersistentFlags().StringVar(&args.context, "context", "", "The name of the kubeconfig context to use")
 	cmd.PersistentFlags().BoolVar(&args.yes, "yes", false, "Do not ask for confirmation")
 	cmd.PersistentFlags().DurationVar(&args.readinessTimeout, "readiness-timeout", 300*time.Second, "Maximum seconds to wait for all Istio resources to be ready."+
-		" The --wait flag must be set for this flag to apply.")
+		" The --wait flag must be set for this flag to apply")
 	cmd.PersistentFlags().BoolVarP(&args.wait, "wait", "w", false, "Wait, if set will wait until all Pods, Services, and minimum number of Pods "+
-		"of a Deployment are in a ready state before the command exits. It will wait for a maximum duration of --readiness-timeout seconds.")
+		"of a Deployment are in a ready state before the command exits. It will wait for a maximum duration of --readiness-timeout seconds")
 	cmd.PersistentFlags().StringSliceVarP(&args.set, "set", "s", nil, setFlagHelpStr)
 }
 

--- a/cmd/mesh/manifest-diff.go
+++ b/cmd/mesh/manifest-diff.go
@@ -58,10 +58,15 @@ func addManifestDiffFlags(cmd *cobra.Command, diffArgs *manifestDiffArgs) {
 
 func manifestDiffCmd(rootArgs *rootArgs, diffArgs *manifestDiffArgs) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "diff",
+		Use:   "diff <file|dir> <file|dir>",
 		Short: "Compare manifests and generate diff.",
 		Long:  "The diff subcommand compares manifests from two files or directories.",
-		Args:  cobra.ExactArgs(2),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return fmt.Errorf("diff requires two files or directories")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if diffArgs.compareDir {
 				compareManifestsFromDirs(rootArgs, args[0], args[1], diffArgs.selectResources, diffArgs.ignoreResources)
@@ -78,11 +83,13 @@ func compareManifestsFromFiles(rootArgs *rootArgs, args []string, selectResource
 
 	a, err := ioutil.ReadFile(args[0])
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not read %q: %v\n", args[0], err.Error())
 		log.Error(err.Error())
 		os.Exit(1)
 	}
 	b, err := ioutil.ReadFile(args[1])
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not read %q: %v\n", args[1], err.Error())
 		log.Error(err.Error())
 		os.Exit(1)
 	}

--- a/cmd/mesh/manifest-diff.go
+++ b/cmd/mesh/manifest-diff.go
@@ -51,15 +51,15 @@ func addManifestDiffFlags(cmd *cobra.Command, diffArgs *manifestDiffArgs) {
 			"The format of each list item is \"::\" and the items are comma separated. The \"*\" character represents wildcard selection.\n"+
 			"e.g.\n"+
 			"    Deployment:istio-system:* - compare all deployments in istio-system namespace\n"+
-			"    Service:*:istio-pilot - compare Services called \"istio-pilot\" in all namespaces.")
+			"    Service:*:istio-pilot - compare Services called \"istio-pilot\" in all namespaces")
 	cmd.PersistentFlags().StringVar(&diffArgs.ignoreResources, "ignore", "",
-		"ignoreResources ignores all listed items during comparison. It uses the same list format as selectResources.")
+		"ignoreResources ignores all listed items during comparison. It uses the same list format as selectResources")
 }
 
 func manifestDiffCmd(rootArgs *rootArgs, diffArgs *manifestDiffArgs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "diff <file|dir> <file|dir>",
-		Short: "Compare manifests and generate diff.",
+		Short: "Compare manifests and generate diff",
 		Long:  "The diff subcommand compares manifests from two files or directories.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 2 {
@@ -68,30 +68,27 @@ func manifestDiffCmd(rootArgs *rootArgs, diffArgs *manifestDiffArgs) *cobra.Comm
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
+			l := newLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.OutOrStderr())
 			if diffArgs.compareDir {
 				compareManifestsFromDirs(rootArgs, args[0], args[1], diffArgs.selectResources, diffArgs.ignoreResources)
 			} else {
-				compareManifestsFromFiles(rootArgs, args, diffArgs.selectResources, diffArgs.ignoreResources)
+				compareManifestsFromFiles(rootArgs, args, diffArgs.selectResources, diffArgs.ignoreResources, l)
 			}
 		}}
 	return cmd
 }
 
 //compareManifestsFromFiles compares two manifest files
-func compareManifestsFromFiles(rootArgs *rootArgs, args []string, selectResources, ignoreResources string) {
+func compareManifestsFromFiles(rootArgs *rootArgs, args []string, selectResources, ignoreResources string, l *logger) {
 	initLogsOrExit(rootArgs)
 
 	a, err := ioutil.ReadFile(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not read %q: %v\n", args[0], err.Error())
-		log.Error(err.Error())
-		os.Exit(1)
+		l.logAndFatal(fmt.Sprintf("Could not read %q: %v\n", args[0], err.Error()))
 	}
 	b, err := ioutil.ReadFile(args[1])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not read %q: %v\n", args[1], err.Error())
-		log.Error(err.Error())
-		os.Exit(1)
+		l.logAndFatal(fmt.Sprintf("Could not read %q: %v\n", args[1], err.Error()))
 	}
 
 	diff, err := object.ManifestDiffWithSelectAndIgnore(string(a), string(b), selectResources, ignoreResources)
@@ -102,7 +99,7 @@ func compareManifestsFromFiles(rootArgs *rootArgs, args []string, selectResource
 	if diff == "" {
 		fmt.Println("Manifests are identical")
 	} else {
-		fmt.Printf("Difference of manifests are:\n%s", diff)
+		fmt.Printf("Differences of manifests are:\n%s", diff)
 		os.Exit(1)
 	}
 }
@@ -134,7 +131,7 @@ func compareManifestsFromDirs(rootArgs *rootArgs, dirName1, dirName2, selectReso
 	if diff == "" {
 		fmt.Println("Manifests are identical")
 	} else {
-		fmt.Printf("Difference of manifests are:\n%s", diff)
+		fmt.Printf("Differences of manifests are:\n%s", diff)
 		os.Exit(1)
 	}
 }

--- a/cmd/mesh/manifest-generate.go
+++ b/cmd/mesh/manifest-generate.go
@@ -28,7 +28,7 @@ import (
 type manifestGenerateArgs struct {
 	// inFilename is the path to the input IstioControlPlane CR.
 	inFilename string
-	// outFilename is the path to the generated output filename.
+	// outFilename is the path to the generated output directory.
 	outFilename string
 	// set is a string with element format "path=value" where path is an IstioControlPlane path and the value is a
 	// value to set the node at that path to.
@@ -37,14 +37,14 @@ type manifestGenerateArgs struct {
 
 func addManifestGenerateFlags(cmd *cobra.Command, args *manifestGenerateArgs) {
 	cmd.PersistentFlags().StringVarP(&args.inFilename, "filename", "f", "", filenameFlagHelpStr)
-	cmd.PersistentFlags().StringVarP(&args.outFilename, "output", "o", "", "Manifest output directory path.")
+	cmd.PersistentFlags().StringVarP(&args.outFilename, "output", "o", "", "Manifest output directory path")
 	cmd.PersistentFlags().StringSliceVarP(&args.set, "set", "s", nil, setFlagHelpStr)
 }
 
 func manifestGenerateCmd(rootArgs *rootArgs, mgArgs *manifestGenerateArgs) *cobra.Command {
 	return &cobra.Command{
 		Use:   "generate",
-		Short: "Generates an Istio install manifest.",
+		Short: "Generates an Istio install manifest",
 		Long:  "The generate subcommand generates an Istio install manifest and outputs to the console by default.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {

--- a/cmd/mesh/manifest-generate.go
+++ b/cmd/mesh/manifest-generate.go
@@ -46,6 +46,12 @@ func manifestGenerateCmd(rootArgs *rootArgs, mgArgs *manifestGenerateArgs) *cobr
 		Use:   "generate",
 		Short: "Generates an Istio install manifest.",
 		Long:  "The generate subcommand generates an Istio install manifest and outputs to the console by default.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("generate accepts no positional arguments, got %#v", args)
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			l := newLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.OutOrStderr())
 			manifestGenerate(rootArgs, mgArgs, l)

--- a/cmd/mesh/manifest-generate_test.go
+++ b/cmd/mesh/manifest-generate_test.go
@@ -138,7 +138,7 @@ func runTestGroup(t *testing.T, tests testGroup) {
 func runManifestGenerate(path, flags string) (string, error) {
 	args := "manifest generate " + flags
 	if flags == "" {
-		args += " -f " + path
+		args += "-f " + path
 	}
 	return runCommand(args)
 }

--- a/cmd/mesh/manifest-migrate.go
+++ b/cmd/mesh/manifest-migrate.go
@@ -16,6 +16,7 @@ package mesh
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 
 	"github.com/ghodss/yaml"
@@ -44,9 +45,15 @@ func addManifestMigrateFlags(cmd *cobra.Command, args *manifestMigrateArgs) {
 
 func manifestMigrateCmd(rootArgs *rootArgs, mmArgs *manifestMigrateArgs) *cobra.Command {
 	return &cobra.Command{
-		Use:   "migrate",
+		Use:   "migrate [<filepath>]",
 		Short: "Migrates a file containing Helm values to IstioControlPlane format.",
 		Long:  "The migrate subcommand migrates a configuration from Helm values format to IstioControlPlane format.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 1 {
+				return fmt.Errorf("migrate accepts optional single filepath")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			l := newLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.OutOrStderr())
 			if len(args) == 0 {
@@ -102,7 +109,7 @@ func translateFunc(values []byte, l *logger) {
 func migrateFromClusterConfig(rootArgs *rootArgs, mmArgs *manifestMigrateArgs, l *logger) {
 	initLogsOrExit(rootArgs)
 
-	l.logAndPrint("translating in cluster specs")
+	l.logAndPrint("translating in cluster specs\n")
 
 	c := kubectlcmd.New()
 	output, stderr, err := c.GetConfig("istio-sidecar-injector", mmArgs.namespace, "jsonpath='{.data.values}'")

--- a/cmd/mesh/manifest-migrate.go
+++ b/cmd/mesh/manifest-migrate.go
@@ -40,13 +40,13 @@ type manifestMigrateArgs struct {
 
 func addManifestMigrateFlags(cmd *cobra.Command, args *manifestMigrateArgs) {
 	cmd.PersistentFlags().StringVarP(&args.namespace, "namespace", "n", defaultNamespace,
-		" Default namespace for output IstioControlPlane CustomResource.")
+		" Default namespace for output IstioControlPlane CustomResource")
 }
 
 func manifestMigrateCmd(rootArgs *rootArgs, mmArgs *manifestMigrateArgs) *cobra.Command {
 	return &cobra.Command{
 		Use:   "migrate [<filepath>]",
-		Short: "Migrates a file containing Helm values to IstioControlPlane format.",
+		Short: "Migrates a file containing Helm values to IstioControlPlane format",
 		Long:  "The migrate subcommand migrates a configuration from Helm values format to IstioControlPlane format.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 1 {
@@ -100,7 +100,7 @@ func translateFunc(values []byte, l *logger) {
 	}
 	cpYaml, _ := yaml.JSONToYAML([]byte(gotString))
 	if err != nil {
-		l.logAndFatal("error converting json: ", gotString, "\n", err.Error())
+		l.logAndFatal("error converting JSON: ", gotString, "\n", err.Error())
 	}
 	l.print(string(cpYaml) + "\n")
 }

--- a/cmd/mesh/manifest-versions.go
+++ b/cmd/mesh/manifest-versions.go
@@ -44,9 +44,15 @@ func addManifestVersionsFlags(cmd *cobra.Command, mvArgs *manifestVersionsArgs) 
 func manifestVersionsCmd(rootArgs *rootArgs, versionsArgs *manifestVersionsArgs) *cobra.Command {
 	return &cobra.Command{
 		Use:   "versions",
-		Short: "List the version of Istio recommended for and supported by this version of the operator binary.",
-		Long:  "List the version of Istio recommended for and supported by this version of the operator binary.",
-		Args:  cobra.ExactArgs(0),
+		Short: "List the versions of Istio recommended for and supported by this version of the operator binary.",
+		Long:  "List the versions of Istio recommended for and supported by this version of the operator binary.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				cmd.Println(cmd.UsageString())
+				return fmt.Errorf("versions accepts no positional arguments")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			l := newLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.OutOrStderr())
 			manifestVersions(rootArgs, versionsArgs, l)

--- a/cmd/mesh/manifest-versions.go
+++ b/cmd/mesh/manifest-versions.go
@@ -38,13 +38,13 @@ type manifestVersionsArgs struct {
 
 func addManifestVersionsFlags(cmd *cobra.Command, mvArgs *manifestVersionsArgs) {
 	cmd.PersistentFlags().StringVarP(&mvArgs.versionsURI, "versionsURI", "u",
-		versionsMapURL, "URI for operator versions to Istio versions map.")
+		versionsMapURL, "URI for operator versions to Istio versions map")
 }
 
 func manifestVersionsCmd(rootArgs *rootArgs, versionsArgs *manifestVersionsArgs) *cobra.Command {
 	return &cobra.Command{
 		Use:   "versions",
-		Short: "List the versions of Istio recommended for and supported by this version of the operator binary.",
+		Short: "List the versions of Istio recommended for and supported by this version of the operator binary",
 		Long:  "List the versions of Istio recommended for and supported by this version of the operator binary.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {

--- a/cmd/mesh/manifest.go
+++ b/cmd/mesh/manifest.go
@@ -38,7 +38,7 @@ import (
 func ManifestCmd() *cobra.Command {
 	mc := &cobra.Command{
 		Use:   "manifest",
-		Short: "Commands related to Istio manifests.",
+		Short: "Commands related to Istio manifests",
 		Long:  "The manifest subcommand generates, applies, diffs or migrates Istio manifests.",
 	}
 

--- a/cmd/mesh/profile-diff.go
+++ b/cmd/mesh/profile-diff.go
@@ -27,10 +27,15 @@ import (
 
 func profileDiffCmd(rootArgs *rootArgs) *cobra.Command {
 	return &cobra.Command{
-		Use:   "diff",
+		Use:   "diff <file1.yaml> <file2.yaml>",
 		Short: "Diffs two Istio configuration profiles.",
 		Long:  "The diff subcommand displays the differences between two Istio configuration profiles.",
-		Args:  cobra.ExactArgs(2),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return fmt.Errorf("diff requires two files")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			profileDiff(rootArgs, args)
 		}}
@@ -43,12 +48,14 @@ func profileDiff(rootArgs *rootArgs, args []string) {
 
 	a, err := helm.ReadProfileYAML(args[0])
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not read %q: %v\n", args[0], err.Error())
 		log.Errorf("could not read the profile values from %s: %s", args[0], err)
 		os.Exit(1)
 	}
 
 	b, err := helm.ReadProfileYAML(args[1])
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not read %q: %v\n", args[1], err.Error())
 		log.Errorf("could not read the profile values from %s: %s", args[1], err)
 		os.Exit(1)
 	}

--- a/cmd/mesh/profile-diff.go
+++ b/cmd/mesh/profile-diff.go
@@ -28,7 +28,7 @@ import (
 func profileDiffCmd(rootArgs *rootArgs) *cobra.Command {
 	return &cobra.Command{
 		Use:   "diff <file1.yaml> <file2.yaml>",
-		Short: "Diffs two Istio configuration profiles.",
+		Short: "Diffs two Istio configuration profiles",
 		Long:  "The diff subcommand displays the differences between two Istio configuration profiles.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 2 {

--- a/cmd/mesh/profile-dump.go
+++ b/cmd/mesh/profile-dump.go
@@ -51,10 +51,15 @@ func addProfileDumpFlags(cmd *cobra.Command, args *profileDumpArgs) {
 
 func profileDumpCmd(rootArgs *rootArgs, pdArgs *profileDumpArgs) *cobra.Command {
 	return &cobra.Command{
-		Use:   "dump",
+		Use:   "dump [<profile>]",
 		Short: "Dumps an Istio configuration profile.",
 		Long:  "The dump subcommand dumps the values in an Istio configuration profile.",
-		Args:  cobra.MaximumNArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 1 {
+				return fmt.Errorf("too many positional arguments")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			l := newLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.OutOrStderr())
 			profileDump(args, rootArgs, pdArgs, l)

--- a/cmd/mesh/profile-dump.go
+++ b/cmd/mesh/profile-dump.go
@@ -44,15 +44,15 @@ type profileDumpArgs struct {
 func addProfileDumpFlags(cmd *cobra.Command, args *profileDumpArgs) {
 	cmd.PersistentFlags().StringVarP(&args.inFilename, "filename", "f", "", filenameFlagHelpStr)
 	cmd.PersistentFlags().StringVarP(&args.configPath, "config-path", "p", "",
-		"The path the root of the configuration subtree to dump e.g. trafficManagement.components.pilot. By default, dump whole tree. ")
+		"The path the root of the configuration subtree to dump e.g. trafficManagement.components.pilot. By default, dump whole tree")
 	cmd.PersistentFlags().BoolVarP(&args.helmValues, "helm-values", "", false,
-		"If set, dumps the Helm values that IstioControlPlaceSpec is translated to before manifests are rendered.")
+		"If set, dumps the Helm values that IstioControlPlaceSpec is translated to before manifests are rendered")
 }
 
 func profileDumpCmd(rootArgs *rootArgs, pdArgs *profileDumpArgs) *cobra.Command {
 	return &cobra.Command{
 		Use:   "dump [<profile>]",
-		Short: "Dumps an Istio configuration profile.",
+		Short: "Dumps an Istio configuration profile",
 		Long:  "The dump subcommand dumps the values in an Istio configuration profile.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 1 {

--- a/cmd/mesh/profile-list.go
+++ b/cmd/mesh/profile-list.go
@@ -25,7 +25,7 @@ import (
 func profileListCmd(rootArgs *rootArgs) *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
-		Short: "Lists available Istio configuration profiles.",
+		Short: "Lists available Istio configuration profiles",
 		Long:  "The list subcommand lists the available Istio configuration profiles.",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/mesh/profile.go
+++ b/cmd/mesh/profile.go
@@ -22,7 +22,7 @@ import (
 func ProfileCmd() *cobra.Command {
 	pc := &cobra.Command{
 		Use:   "profile",
-		Short: "Commands related to Istio configuration profiles.",
+		Short: "Commands related to Istio configuration profiles",
 		Long:  "The profile subcommand lists, dumps or diffs Istio configuration profiles.",
 	}
 

--- a/cmd/mesh/root.go
+++ b/cmd/mesh/root.go
@@ -26,8 +26,8 @@ import (
 const (
 	setFlagHelpStr = `Set a value in IstioControlPlane CustomResource. e.g. --set policy.enabled=true.
 Overrides the corresponding path value in the selected profile or passed through IstioControlPlane CR
-customization file.`
-	filenameFlagHelpStr = `Path to file containing IstioControlPlane CustomResource.`
+customization file`
+	filenameFlagHelpStr = `Path to file containing IstioControlPlane CustomResource`
 )
 
 type rootArgs struct {

--- a/cmd/mesh/shared.go
+++ b/cmd/mesh/shared.go
@@ -69,6 +69,7 @@ func (l *logger) logAndPrint(v ...interface{}) {
 	s := fmt.Sprint(v...)
 	if !l.logToStdErr {
 		l.print(s)
+		l.print("\n")
 	}
 	log.Infof(s)
 }

--- a/pkg/kubectlcmd/client.go
+++ b/pkg/kubectlcmd/client.go
@@ -91,7 +91,7 @@ func (c *Client) Apply(dryRun, verbose bool, kubeconfig, context, namespace stri
 	err := c.cmdSite.Run(cmd)
 	if err != nil {
 		logAndPrint("error running kubectl apply: %s", err)
-		return stdout.String(), stderr.String(), fmt.Errorf("error from running kubectl apply: %s", err)
+		return stdout.String(), stderr.String(), fmt.Errorf("error running kubectl apply: %s", err)
 	}
 
 	logAndPrint("kubectl apply success")
@@ -120,7 +120,7 @@ func (c *Client) GetConfig(name, namespace, output string, extraArgs ...string) 
 	err := c.cmdSite.Run(cmd)
 	if err != nil {
 		logAndPrint("error running kubectl get cm: %s", err)
-		return stdout.String(), stderr.String(), fmt.Errorf("error from running kubectl get cm: %s", err)
+		return stdout.String(), stderr.String(), fmt.Errorf("error running kubectl %s: %s", strings.Join(args, " "), err)
 	}
 
 	logAndPrint("kubectl get cm success")


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/16814 by addition argument checking, usage hints for positional messages.

Requires `--yes` in `mesh apply` if the file, kubeconfig, or context has not been specified.  (This is to keep the user from typing it by accident and applying a change to her cluster!)