### PR TITLE
manifest diff: add text diff when --verbose flag is set.

### DIFF
--- a/cmd/mesh/manifest-diff.go
+++ b/cmd/mesh/manifest-diff.go
@@ -87,7 +87,8 @@ func compareManifestsFromFiles(rootArgs *rootArgs, args []string, selectResource
 		os.Exit(1)
 	}
 
-	diff, err := object.ManifestDiffWithSelectAndIgnore(string(a), string(b), selectResources, ignoreResources)
+	diff, err := object.ManifestDiffWithSelectAndIgnore(string(a), string(b), selectResources,
+		ignoreResources, rootArgs.verbose)
 	if err != nil {
 		log.Error(err.Error())
 		os.Exit(1)
@@ -119,7 +120,8 @@ func compareManifestsFromDirs(rootArgs *rootArgs, dirName1, dirName2, selectReso
 		os.Exit(1)
 	}
 
-	diff, err := object.ManifestDiffWithSelectAndIgnore(mf1, mf2, selectResources, ignoreResources)
+	diff, err := object.ManifestDiffWithSelectAndIgnore(mf1, mf2, selectResources,
+		ignoreResources, rootArgs.verbose)
 	if err != nil {
 		log.Error(err.Error())
 		os.Exit(1)

--- a/cmd/mesh/manifest-generate_test.go
+++ b/cmd/mesh/manifest-generate_test.go
@@ -141,19 +141,15 @@ func runTestGroup(t *testing.T, tests testGroup) {
 			if tt.diffSelect != "" {
 				diffSelect = tt.diffSelect
 			}
-			diff, err := object.ManifestDiffWithSelectAndIgnore(got, want, diffSelect, tt.diffIgnore, false)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if diff != "" {
-				t.Errorf("%s: got:\n%s\nwant:\n%s\n(-got, +want)\n%s\n", tt.desc, "", "", diff)
-			}
-			diffVerbose, err := object.ManifestDiffWithSelectAndIgnore(got, want, diffSelect, tt.diffIgnore, true)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if diff != "" {
-				t.Errorf("%s: got:\n%s\nwant:\n%s\n(-got, +want)\n%s\n", tt.desc, "", "", diffVerbose)
+
+			for _, v := range []bool{true, false} {
+				diff, err := object.ManifestDiffWithSelectAndIgnore(got, want, diffSelect, tt.diffIgnore, v)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if diff != "" {
+					t.Errorf("%s: got:\n%s\nwant:\n%s\n(-got, +want)\n%s\n", tt.desc, "", "", diff)
+				}
 			}
 
 		})

--- a/cmd/mesh/manifest-generate_test.go
+++ b/cmd/mesh/manifest-generate_test.go
@@ -141,12 +141,19 @@ func runTestGroup(t *testing.T, tests testGroup) {
 			if tt.diffSelect != "" {
 				diffSelect = tt.diffSelect
 			}
-			diff, err := object.ManifestDiffWithSelectAndIgnore(got, want, diffSelect, tt.diffIgnore)
+			diff, err := object.ManifestDiffWithSelectAndIgnore(got, want, diffSelect, tt.diffIgnore, false)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if diff != "" {
 				t.Errorf("%s: got:\n%s\nwant:\n%s\n(-got, +want)\n%s\n", tt.desc, "", "", diff)
+			}
+			diffVerbose, err := object.ManifestDiffWithSelectAndIgnore(got, want, diffSelect, tt.diffIgnore, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff != "" {
+				t.Errorf("%s: got:\n%s\nwant:\n%s\n(-got, +want)\n%s\n", tt.desc, "", "", diffVerbose)
 			}
 
 		})

--- a/pkg/object/objects_test.go
+++ b/pkg/object/objects_test.go
@@ -630,13 +630,10 @@ spec:
 
 	for _, tt := range manifestDiffTests {
 		t.Run(tt.desc, func(t *testing.T) {
-			got, err := ManifestDiff(tt.yamlStringA, tt.yamlStringB)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !strings.Contains(got, tt.want) {
-				t.Errorf("%s:\ngot:\n%v\ndoes't contains\nwant:\n%v", tt.desc, got, tt.want)
-			}
+			got, err := ManifestDiff(tt.yamlStringA, tt.yamlStringB, false)
+			reportDiffErr(err, t, tt.desc, got, tt.want)
+			gotVerbose, err := ManifestDiff(tt.yamlStringA, tt.yamlStringB, true)
+			reportDiffErr(err, t, tt.desc, gotVerbose, tt.want)
 		})
 	}
 }
@@ -816,13 +813,21 @@ spec:
 
 	for _, tt := range manifestDiffWithSelectAndIgnoreTests {
 		t.Run(tt.desc, func(t *testing.T) {
-			got, err := ManifestDiffWithSelectAndIgnore(tt.yamlStringA, tt.yamlStringB, tt.selectResources, tt.ignoreResources)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !strings.Contains(got, tt.want) {
-				t.Errorf("%s:\ngot:\n%v\ndoes't contains\nwant:\n%v", tt.desc, got, tt.want)
-			}
+			got, err := ManifestDiffWithSelectAndIgnore(tt.yamlStringA, tt.yamlStringB,
+				tt.selectResources, tt.ignoreResources, false)
+			reportDiffErr(err, t, tt.desc, got, tt.want)
+			gotVerbose, err := ManifestDiffWithSelectAndIgnore(tt.yamlStringA, tt.yamlStringB,
+				tt.selectResources, tt.ignoreResources, true)
+			reportDiffErr(err, t, tt.desc, gotVerbose, tt.want)
 		})
+	}
+}
+
+func reportDiffErr(err error, t *testing.T, desc, got, want string) {
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got, want) {
+		t.Errorf("%s:\ngot:\n%v\ndoes't contains\nwant:\n%v", desc, got, want)
 	}
 }

--- a/pkg/object/objects_test.go
+++ b/pkg/object/objects_test.go
@@ -629,12 +629,17 @@ spec:
 	}
 
 	for _, tt := range manifestDiffTests {
-		t.Run(tt.desc, func(t *testing.T) {
-			got, err := ManifestDiff(tt.yamlStringA, tt.yamlStringB, false)
-			reportDiffErr(err, t, tt.desc, got, tt.want)
-			gotVerbose, err := ManifestDiff(tt.yamlStringA, tt.yamlStringB, true)
-			reportDiffErr(err, t, tt.desc, gotVerbose, tt.want)
-		})
+		for _, v := range []bool{true, false} {
+			t.Run(tt.desc, func(t *testing.T) {
+				got, err := ManifestDiff(tt.yamlStringA, tt.yamlStringB, v)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !strings.Contains(got, tt.want) {
+					t.Errorf("%s:\ngot:\n%v\ndoes't contains\nwant:\n%v", tt.desc, got, tt.want)
+				}
+			})
+		}
 	}
 }
 
@@ -812,22 +817,17 @@ spec:
 	}
 
 	for _, tt := range manifestDiffWithSelectAndIgnoreTests {
-		t.Run(tt.desc, func(t *testing.T) {
-			got, err := ManifestDiffWithSelectAndIgnore(tt.yamlStringA, tt.yamlStringB,
-				tt.selectResources, tt.ignoreResources, false)
-			reportDiffErr(err, t, tt.desc, got, tt.want)
-			gotVerbose, err := ManifestDiffWithSelectAndIgnore(tt.yamlStringA, tt.yamlStringB,
-				tt.selectResources, tt.ignoreResources, true)
-			reportDiffErr(err, t, tt.desc, gotVerbose, tt.want)
-		})
-	}
-}
-
-func reportDiffErr(err error, t *testing.T, desc, got, want string) {
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(got, want) {
-		t.Errorf("%s:\ngot:\n%v\ndoes't contains\nwant:\n%v", desc, got, want)
+		for _, v := range []bool{true, false} {
+			t.Run(tt.desc, func(t *testing.T) {
+				got, err := ManifestDiffWithSelectAndIgnore(tt.yamlStringA, tt.yamlStringB,
+					tt.selectResources, tt.ignoreResources, v)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !strings.Contains(got, tt.want) {
+					t.Errorf("%s:\ngot:\n%v\ndoes't contains\nwant:\n%v", tt.desc, got, tt.want)
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
Resolve: https://github.com/istio/istio/issues/16827

manifest diff: add text diff when --verbose flag is set. 
Sometimes, the text diff format (used in mesh profile diff) is easier to read than the compact diff style used in mesh manifest diff. Reuse the existing tests to also test verbose output.