### PR TITLE
Add obj diff inside the yaml text in ConfigMap data

### DIFF
--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -92,12 +92,12 @@ func YAMLCmpWithIgnore(a, b string, ignorePaths []string) string {
 		return err.Error()
 	}
 
-	if kind, ok := ao["kind"]; ok && kind == "ConfigMap" {
+	if kind := ao["kind"]; kind == "ConfigMap" {
 		if err := UnmarshalInlineYaml(ao, "data"); err != nil {
 			log.Warnf("Unable to unmarshal ConfigMap Data, error: %v", err)
 		}
 	}
-	if kind, ok := bo["kind"]; ok && kind == "ConfigMap" {
+	if kind := bo["kind"]; kind == "ConfigMap" {
 		if err := UnmarshalInlineYaml(bo, "data"); err != nil {
 			log.Warnf("Unable to unmarshal ConfigMap Data, error: %v", err)
 		}

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -662,3 +662,230 @@ metadata:
 		})
 	}
 }
+
+func TestYAMLCmpWithYamlInline(t *testing.T) {
+	tests := []struct {
+		desc string
+		a    string
+		b    string
+		want interface{}
+	}{
+		{
+			desc: "ConfigMap data identical",
+			a: `kind: ConfigMap
+data:
+  validatingwebhookconfiguration.yaml: |-
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: istio-galley`,
+			b: `kind: ConfigMap
+data:
+  validatingwebhookconfiguration.yaml: |-
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: istio-galley`,
+			want: ``,
+		},
+		{
+			desc: "ConfigMap data order changed",
+			a: `kind: ConfigMap
+data:
+  validatingwebhookconfiguration.yaml: |-
+    kind: ValidatingWebhookConfiguration
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    metadata:
+      name: istio-galley
+      value: foo`,
+			b: `kind: ConfigMap
+data:
+  validatingwebhookconfiguration.yaml: |-
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      value: foo
+      name: istio-galley`,
+			want: ``,
+		},
+		{
+			desc: "ConfigMap data value change",
+			a: `kind: ConfigMap
+data:
+  validatingwebhookconfiguration.yaml: |-
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: istio-galley`,
+			b: `kind: ConfigMap
+data:
+  validatingwebhookconfiguration.yaml: |-
+    apiVersion: admissionregistration.k8s.io/v1beta2
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: istio-galley`,
+			want: `data:
+  validatingwebhookconfiguration.yaml:
+    apiVersion: admissionregistration.k8s.io/v1beta1 -> admissionregistration.k8s.io/v1beta2
+`,
+		},
+		{
+			desc: "ConfigMap data string change",
+			a: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: injector-mesh
+  namespace: istio-system
+  labels:
+    release: istio
+data:
+  mesh: |-
+    defaultConfig:
+      connectTimeout: 10s
+      configPath: "/etc/istio/proxyv1"
+      serviceCluster: istio-proxy
+      drainDuration: 45s
+      parentShutdownDuration: 1m0s
+      proxyAdminPort: 15000
+      concurrency: 2
+      tracing:
+        zipkin:
+          address: zipkin.istio-system:9411
+      controlPlaneAuthPolicy: NONE
+      discoveryAddress: istio-pilot.istio-system:15010`,
+			b: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: injector-mesh
+  namespace: istio-system
+  labels:
+    release: istio
+data:
+  mesh: |-
+    defaultConfig:
+      connectTimeout: 10s
+      configPath: "/etc/istio/proxyv2"
+      serviceCluster: istio-proxy
+      drainDuration: 45s
+      parentShutdownDuration: 1m0s
+      proxyAdminPort: 15000
+      concurrency: 2
+      tracing:
+        zipkin:
+          address: zipkin.istio-system:9411
+      controlPlaneAuthPolicy: NONE
+      discoveryAddress: istio-pilot.istio-system:15010`,
+			want: `data:
+  mesh:
+    defaultConfig:
+      configPath: /etc/istio/proxyv1 -> /etc/istio/proxyv2
+`,
+		},
+		{
+			desc: "ConfigMap data multiple changes",
+			a: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: injector-mesh
+  namespace: istio-system
+  labels:
+    release: istio
+data:
+  mesh: |-
+    defaultConfig:
+      connectTimeout: 10s
+      configPath: "/etc/istio/proxyv1"
+      serviceCluster: istio-proxy
+      drainDuration: 45s
+      parentShutdownDuration: 1m0s
+      proxyAdminPortA: 15000
+      concurrency: 2
+      tracing:
+        zipkin:
+          address: zipkin.istio-system:9411
+      controlPlaneAuthPolicy: NONE
+      discoveryAddress: istio-pilot.istio-system:15010`,
+			b: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: injector-mesh
+  namespace: istio-system
+  labels:
+    release: istio
+data:
+  mesh: |-
+    defaultConfig:
+      connectTimeout: 10s
+      configPath: "/etc/istio/proxyv2"
+      serviceCluster: istio-proxy
+      drainDuration: 45s
+      parentShutdownDuration: 1m0s
+      proxyAdminPortB: 15000
+      concurrency: 2
+      tracing:
+        zipkin:
+          address: zipkin.istio-system:9411
+      controlPlaneAuthPolicy: NONE
+      discoveryAddress: istio-pilot.istio-system:15010`,
+			want: `data:
+  mesh:
+    defaultConfig:
+      configPath: /etc/istio/proxyv1 -> /etc/istio/proxyv2
+      proxyAdminPortA: 15000 ->
+      proxyAdminPortB: -> 15000
+`,
+		},
+		{
+			desc: "Not ConfigMap, identical",
+			a: `kind: Config
+data:
+  validatingwebhookconfiguration.yaml: |-
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: istio-galley`,
+			b: `kind: Config
+data:
+  validatingwebhookconfiguration.yaml: |-
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: istio-galley`,
+			want: ``,
+		},
+		{
+			desc: "Not ConfigMap, Order changed",
+			a: `kind: Config
+data:
+  validatingwebhookconfiguration.yaml: |-
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: istio-galley`,
+			b: `kind: Config
+data:
+  validatingwebhookconfiguration.yaml: |-
+    kind: ValidatingWebhookConfiguration
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    metadata:
+      name: istio-galley`,
+			want: `data:
+  validatingwebhookconfiguration.yaml: |-
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: istio-galley -> kind: ValidatingWebhookConfiguration
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    metadata:
+      name: istio-galley
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got, want := YAMLCmp(tt.a, tt.b), tt.want; !(got == want) {
+				t.Errorf("%s: got:%v, want:%v", tt.desc, got, want)
+			}
+		})
+	}
+}

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -671,24 +671,6 @@ func TestYAMLCmpWithYamlInline(t *testing.T) {
 		want interface{}
 	}{
 		{
-			desc: "ConfigMap data identical",
-			a: `kind: ConfigMap
-data:
-  validatingwebhookconfiguration.yaml: |-
-    apiVersion: admissionregistration.k8s.io/v1beta1
-    kind: ValidatingWebhookConfiguration
-    metadata:
-      name: istio-galley`,
-			b: `kind: ConfigMap
-data:
-  validatingwebhookconfiguration.yaml: |-
-    apiVersion: admissionregistration.k8s.io/v1beta1
-    kind: ValidatingWebhookConfiguration
-    metadata:
-      name: istio-galley`,
-			want: ``,
-		},
-		{
 			desc: "ConfigMap data order changed",
 			a: `kind: ConfigMap
 data:
@@ -720,8 +702,8 @@ data:
 			b: `kind: ConfigMap
 data:
   validatingwebhookconfiguration.yaml: |-
-    apiVersion: admissionregistration.k8s.io/v1beta2
     kind: ValidatingWebhookConfiguration
+    apiVersion: admissionregistration.k8s.io/v1beta2
     metadata:
       name: istio-galley`,
 			want: `data:
@@ -730,55 +712,37 @@ data:
 `,
 		},
 		{
-			desc: "ConfigMap data string change",
+			desc: "ConfigMap data deep nested value change",
 			a: `apiVersion: v1
 kind: ConfigMap
 metadata:
   name: injector-mesh
-  namespace: istio-system
-  labels:
-    release: istio
 data:
   mesh: |-
     defaultConfig:
-      connectTimeout: 10s
-      configPath: "/etc/istio/proxyv1"
-      serviceCluster: istio-proxy
-      drainDuration: 45s
-      parentShutdownDuration: 1m0s
-      proxyAdminPort: 15000
-      concurrency: 2
       tracing:
         zipkin:
           address: zipkin.istio-system:9411
       controlPlaneAuthPolicy: NONE
-      discoveryAddress: istio-pilot.istio-system:15010`,
+      connectTimeout: 10s`,
 			b: `apiVersion: v1
 kind: ConfigMap
 metadata:
   name: injector-mesh
-  namespace: istio-system
-  labels:
-    release: istio
 data:
   mesh: |-
     defaultConfig:
       connectTimeout: 10s
-      configPath: "/etc/istio/proxyv2"
-      serviceCluster: istio-proxy
-      drainDuration: 45s
-      parentShutdownDuration: 1m0s
-      proxyAdminPort: 15000
-      concurrency: 2
       tracing:
         zipkin:
-          address: zipkin.istio-system:9411
-      controlPlaneAuthPolicy: NONE
-      discoveryAddress: istio-pilot.istio-system:15010`,
+          address: zipkin.istio-system:9412
+      controlPlaneAuthPolicy: NONE`,
 			want: `data:
   mesh:
     defaultConfig:
-      configPath: /etc/istio/proxyv1 -> /etc/istio/proxyv2
+      tracing:
+        zipkin:
+          address: zipkin.istio-system:9411 -> zipkin.istio-system:9412
 `,
 		},
 		{


### PR DESCRIPTION
Resolve: https://github.com/istio/istio/issues/16828

ConfigMaps are typically text blocks of YAML and are unmarshaled as a single string, making YAML diffing impossible. 

Solution: automatically try to unmarshal ConfigMap data string into YAML and if that succeeds, diff based on the unmarshaled yaml tree.