### PR TITLE
manifest diff: add resource rename flag 

### DIFF
--- a/cmd/mesh/manifest-generate_test.go
+++ b/cmd/mesh/manifest-generate_test.go
@@ -181,7 +181,8 @@ func runTestGroup(t *testing.T, tests testGroup) {
 			}
 
 			for _, v := range []bool{true, false} {
-				diff, err := object.ManifestDiffWithSelectAndIgnore(got, want, diffSelect, tt.diffIgnore, v)
+				diff, err := object.ManifestDiffWithRenameSelectIgnore(got, want,
+					"", diffSelect, tt.diffIgnore, v)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/object/objects.go
+++ b/pkg/object/objects.go
@@ -385,14 +385,35 @@ func ManifestDiff(a, b string, verbose bool) (string, error) {
 
 // ManifestDiffWithSelect checks the manifest differences with selected and ignored resources.
 // The selected filter will apply before the ignored filter.
-func ManifestDiffWithSelectAndIgnore(a, b, selectResources, ignoreResources string, verbose bool) (string, error) {
+func ManifestDiffWithRenameSelectIgnore(a, b, renameResources, selectResources, ignoreResources string, verbose bool) (string, error) {
+	rnm := getKeyValueMap(renameResources)
 	sm := getObjPathMap(selectResources)
 	im := getObjPathMap(ignoreResources)
-	aosm, err := filterResourceWithSelectAndIgnore(a, sm, im)
+
+	ao, err := ParseK8sObjectsFromYAMLManifest(a)
 	if err != nil {
 		return "", err
 	}
-	bosm, err := filterResourceWithSelectAndIgnore(b, sm, im)
+	aom := ao.ToMap()
+
+	bo, err := ParseK8sObjectsFromYAMLManifest(b)
+	if err != nil {
+		return "", err
+	}
+	bom := bo.ToMap()
+
+	if len(rnm) != 0 {
+		aom, err = renameResource(aom, rnm)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	aosm, err := filterResourceWithSelectAndIgnore(aom, sm, im)
+	if err != nil {
+		return "", err
+	}
+	bosm, err := filterResourceWithSelectAndIgnore(bom, sm, im)
 	if err != nil {
 		return "", err
 	}
@@ -400,13 +421,51 @@ func ManifestDiffWithSelectAndIgnore(a, b, selectResources, ignoreResources stri
 	return manifestDiff(aosm, bosm, im, verbose)
 }
 
-// filterResourceWithSelectAndIgnore filter the input resources with selected and ignored filter.
-func filterResourceWithSelectAndIgnore(a string, sm, im map[string]string) (map[string]*K8sObject, error) {
-	ao, err := ParseK8sObjectsFromYAMLManifest(a)
-	if err != nil {
-		return nil, err
+// renameResource filter the input resources with selected and ignored filter.
+func renameResource(iom map[string]*K8sObject, rnm map[string]string) (map[string]*K8sObject, error) {
+	oom := make(map[string]*K8sObject)
+	for name, obj := range iom {
+		isRenamed := false
+		for fromPat, toPat := range rnm {
+			fromRe, err := buildResourceRegexp(strings.TrimSpace(fromPat))
+			if err != nil {
+				return nil, fmt.Errorf("error building the resource regexp: %v", err)
+			}
+			if fromRe.MatchString(name) {
+				fromList := strings.Split(name, ":")
+				if len(fromList) != 3 {
+					return nil, fmt.Errorf("failed to split renamed-from format,"+
+						" length != 3: %v", fromPat)
+				}
+				toList := strings.Split(toPat, ":")
+				if len(toList) != 3 {
+					return nil, fmt.Errorf("failed to split renamed-to format,"+
+						" length != 3: %v", toPat)
+				}
+
+				// Use original name if new pattern has regex
+				newNameList := make([]string, 3)
+				for i := range toList {
+					if toList[i] == "" || toList[i] == "*" {
+						newNameList[i] = fromList[i]
+					} else {
+						newNameList[i] = toList[i]
+					}
+				}
+				tk := strings.Join(newNameList, ":")
+				oom[tk] = obj
+				isRenamed = true
+			}
+		}
+		if !isRenamed {
+			oom[name] = obj
+		}
 	}
-	aom := ao.ToMap()
+	return oom, nil
+}
+
+// filterResourceWithSelectAndIgnore filter the input resources with selected and ignored filter.
+func filterResourceWithSelectAndIgnore(aom map[string]*K8sObject, sm, im map[string]string) (map[string]*K8sObject, error) {
 	aosm := make(map[string]*K8sObject)
 	for ak, av := range aom {
 		for selected := range sm {
@@ -510,6 +569,21 @@ func getObjPathMap(rs string) map[string]string {
 		kind, namespace, name, path := split[0], split[1], split[2], split[3]
 		obj := fmt.Sprintf("%v:%v:%v", kind, namespace, name)
 		rm[obj] = path
+	}
+	return rm
+}
+
+func getKeyValueMap(rs string) map[string]string {
+	rm := make(map[string]string)
+	if len(rs) == 0 {
+		return rm
+	}
+	for _, r := range strings.Split(rs, ",") {
+		split := strings.Split(r, "->")
+		if len(split) != 2 {
+			continue
+		}
+		rm[split[0]] = split[1]
 	}
 	return rm
 }

--- a/pkg/object/objects.go
+++ b/pkg/object/objects.go
@@ -429,30 +429,32 @@ func renameResource(iom map[string]*K8sObject, rnm map[string]string) (map[strin
 		for fromPat, toPat := range rnm {
 			fromRe, err := buildResourceRegexp(strings.TrimSpace(fromPat))
 			if err != nil {
-				return nil, fmt.Errorf("error building the resource regexp: %v", err)
+				return nil, fmt.Errorf("error building the regexp from "+
+					"rename-from string: %v, error: %v", fromPat, err)
 			}
 			if fromRe.MatchString(name) {
 				fromList := strings.Split(name, ":")
 				if len(fromList) != 3 {
-					return nil, fmt.Errorf("failed to split renamed-from format,"+
-						" length != 3: %v", fromPat)
+					return nil, fmt.Errorf("failed to split the old name,"+
+						" length != 3: %v", name)
 				}
 				toList := strings.Split(toPat, ":")
 				if len(toList) != 3 {
-					return nil, fmt.Errorf("failed to split renamed-to format,"+
+					return nil, fmt.Errorf("failed to split the rename-to string,"+
 						" length != 3: %v", toPat)
 				}
 
-				// Use original name if new pattern has regex
-				newNameList := make([]string, 3)
+				// Use the old name if toList has "*" or ""
+				// Otherwise, use the name in toList
+				newList := make([]string, 3)
 				for i := range toList {
 					if toList[i] == "" || toList[i] == "*" {
-						newNameList[i] = fromList[i]
+						newList[i] = fromList[i]
 					} else {
-						newNameList[i] = toList[i]
+						newList[i] = toList[i]
 					}
 				}
-				tk := strings.Join(newNameList, ":")
+				tk := strings.Join(newList, ":")
 				oom[tk] = obj
 				isRenamed = true
 			}

--- a/pkg/object/objects_test.go
+++ b/pkg/object/objects_test.go
@@ -819,8 +819,8 @@ spec:
 	for _, tt := range manifestDiffWithSelectAndIgnoreTests {
 		for _, v := range []bool{true, false} {
 			t.Run(tt.desc, func(t *testing.T) {
-				got, err := ManifestDiffWithSelectAndIgnore(tt.yamlStringA, tt.yamlStringB,
-					tt.selectResources, tt.ignoreResources, v)
+				got, err := ManifestDiffWithRenameSelectIgnore(tt.yamlStringA, tt.yamlStringB,
+					"", tt.selectResources, tt.ignoreResources, v)
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
@@ -829,5 +829,176 @@ spec:
 				}
 			})
 		}
+	}
+}
+
+func TestManifestDiffWithRenameSelectIgnore(t *testing.T) {
+	testDeploymentYaml := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istio-citadel
+  namespace: istio-system
+  labels:
+    istio: citadel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      istio: citadel
+  template:
+    metadata:
+      labels:
+        istio: citadel
+    spec:
+      containers:
+      - name: citadel
+        image: docker.io/istio/citadel:1.1.8
+---
+`
+
+	testDeploymentYamlRenamed := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istio-ca
+  namespace: istio-system
+  labels:
+    istio: citadel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      istio: citadel
+  template:
+    metadata:
+      labels:
+        istio: citadel
+    spec:
+      containers:
+      - name: citadel
+        image: docker.io/istio/citadel:1.1.8
+---
+`
+
+	testServiceYaml := `apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: pilot
+  name: istio-pilot
+  namespace: istio-system
+spec:
+  type: ClusterIP
+  ports:
+  - name: grpc-xds
+    port: 15010
+    protocol: TCP
+    targetPort: 15010
+  - name: http-monitoring
+    port: 15014
+    protocol: TCP
+    targetPort: 15014
+  selector:
+    istio: pilot
+---
+`
+
+	testServiceYamlRenamed := `apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: pilot
+  name: istio-control
+  namespace: istio-system
+spec:
+  type: ClusterIP
+  ports:
+  - name: grpc-xds
+    port: 15010
+    protocol: TCP
+    targetPort: 15010
+  - name: http-monitoring
+    port: 15014
+    protocol: TCP
+    targetPort: 15014
+  selector:
+    istio: pilot
+---
+`
+
+	manifestDiffWithRenameSelectIgnoreTests := []struct {
+		desc            string
+		yamlStringA     string
+		yamlStringB     string
+		renameResources string
+		selectResources string
+		ignoreResources string
+		want            string
+	}{
+		{
+			"ManifestDiffDeployWithRenamedFlagMultiResource",
+			testDeploymentYaml + YAMLSeparator + testServiceYaml,
+			testDeploymentYamlRenamed + YAMLSeparator + testServiceYamlRenamed,
+			"Service:istio-system:istio-pilot->Service:istio-system:istio-control,Deployment:istio-system:istio-citadel->Deployment:istio-system:istio-ca",
+			"::",
+			"",
+			`
+
+Object Deployment:istio-system:istio-ca has diffs:
+
+metadata:
+  name: istio-citadel -> istio-ca
+
+
+Object Service:istio-system:istio-control has diffs:
+
+metadata:
+  name: istio-pilot -> istio-control
+`,
+		},
+		{
+			"ManifestDiffDeployWithRenamedFlag",
+			testDeploymentYaml,
+			testDeploymentYamlRenamed,
+			"Deployment:istio-system:istio-citadel->Deployment:istio-system:istio-ca",
+			"::",
+			"",
+			`
+
+Object Deployment:istio-system:istio-ca has diffs:
+
+metadata:
+  name: istio-citadel -> istio-ca
+`,
+		},
+		{
+			"ManifestDiffRenamedDeploy",
+			testDeploymentYaml,
+			testDeploymentYamlRenamed,
+			"",
+			"::",
+			"",
+			`
+
+Object Deployment:istio-system:istio-ca is missing in A:
+
+
+
+Object Deployment:istio-system:istio-citadel is missing in B:
+
+`,
+		},
+	}
+
+	for _, tt := range manifestDiffWithRenameSelectIgnoreTests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := ManifestDiffWithRenameSelectIgnore(tt.yamlStringA, tt.yamlStringB,
+				tt.renameResources, tt.selectResources, tt.ignoreResources, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("%s:\ngot:\n%v\ndoes't equals to\nwant:\n%v", tt.desc, got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/object/objects_test.go
+++ b/pkg/object/objects_test.go
@@ -935,6 +935,27 @@ spec:
 		want            string
 	}{
 		{
+			"ManifestDiffDeployWithRenamedFlagMultiResourceWildcard",
+			testDeploymentYaml + YAMLSeparator + testServiceYaml,
+			testDeploymentYamlRenamed + YAMLSeparator + testServiceYamlRenamed,
+			"Service:*:istio-pilot->::istio-control,Deployment::istio-citadel->::istio-ca",
+			"::",
+			"",
+			`
+
+Object Deployment:istio-system:istio-ca has diffs:
+
+metadata:
+  name: istio-citadel -> istio-ca
+
+
+Object Service:istio-system:istio-control has diffs:
+
+metadata:
+  name: istio-pilot -> istio-control
+`,
+		},
+		{
 			"ManifestDiffDeployWithRenamedFlagMultiResource",
 			testDeploymentYaml + YAMLSeparator + testServiceYaml,
 			testDeploymentYamlRenamed + YAMLSeparator + testServiceYamlRenamed,


### PR DESCRIPTION
Resolve: https://github.com/istio/istio/issues/16826
manifest diff: add resource rename flag to be able to diff a name-changed resource.

Example if you have `BUILD_WITH_CONTAINER=0 make mandiff` executed locally.

``` bash
mesh manifest diff --ignore ConfigMap::istio:data.values.yaml  \
--directory /tmp/istio-mandiff-out/helm-template/istio-sds \
/tmp/istio-mandiff-out/mesh-manifest/istio-sds \
--rename 'HorizontalPodAutoscaler:istio-system:istio-telemetry->HorizontalPodAutoscaler:istio-system:istio-telemetry-renamed'
```
Output
```
Differences of manifests are:

Object HorizontalPodAutoscaler:istio-system:istio-telemetry-renamed has diffs:

metadata:
  name: istio-telemetry -> istio-telemetry-renamed
```
