### PR TITLE
Remove v1alpha1 based values validation.

### DIFF
--- a/pkg/validate/validate_values.go
+++ b/pkg/validate/validate_values.go
@@ -15,9 +15,6 @@
 package validate
 
 import (
-	"github.com/ghodss/yaml"
-
-	"istio.io/operator/pkg/apis/istio/v1alpha1"
 	"istio.io/operator/pkg/util"
 )
 
@@ -33,14 +30,6 @@ var (
 
 // CheckValues validates the values in the given tree, which follows the Istio values.yaml schema.
 func CheckValues(root map[string]interface{}) util.Errors {
-	vs, err := yaml.Marshal(root)
-	if err != nil {
-		return util.Errors{err}
-	}
-	val := &v1alpha1.Values{}
-	if err := util.UnmarshalValuesWithJSONPB(string(vs), val); err != nil {
-		return util.Errors{err}
-	}
 	return validateValues(defaultValuesValidations, root, nil)
 }
 


### PR DESCRIPTION
The current values validation is based on the model from v1alpha1. Since v1alpha1 is not updated, let's remove this to not block adding new fields into config (e.g., profiles/default.yaml).