### PR TITLE
Remove extra quotes from CONTAINER_OPTIONS

### DIFF
--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CONTAINER_OPTIONS=--mount type=volume,source=istio-installer-cache,destination="${GOPATH}/src/istio.io"
+CONTAINER_OPTIONS=--mount type=volume,source=istio-installer-cache,destination=${GOPATH}/src/istio.io
 
 # this repo is on the container plan by default
 BUILD_WITH_CONTAINER ?= 1


### PR DESCRIPTION
When this variable is exported to be used by the new run-docker script, the literal quotes in it become escaped. Bash convention has a soft opposition to putting "code" in variables, so there's no good way of converting literal quotes into syntactic quotes.

Hopefully nobody has spaces in their GOPATH, but this wouldn't have worked anyway since those were literal quotes and Docker doesn't know how to handle that.

istio/common-files#94