### PR TITLE
Permit overriding of the Makefile HUB and TAG

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG ?= latest
+HUB ?= gcr.io/istio-testing
+TAG ?= master-latest-daily
 
 pwd := $(shell pwd)
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: docker.io/istio/controller
+          image: gcr.io/istio-release/operator:master_latest_daily
           command:
           - istio-operator
           - server


### PR DESCRIPTION
Also set the HUB and TAG consistently with other projects.
The manifest itself would need manual modification to choose a
different HUB and TAG. Rather than introduce helm for such an action
I'd prefer some other method...