### PR TITLE
update build output path.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ bin/protoc-gen-gogoslick*
 bin/protoc-min-version*
 bin/protoc-gen-docs*
 *.orig
-build/_output/
 .mesh-cli.log
 #mandiff output
 out/

--- a/hack/sdk
+++ b/hack/sdk
@@ -3,9 +3,9 @@
 SOURCE_DIR=$(dirname "${BASH_SOURCE}")
 pushd ${SOURCE_DIR}/.. > /dev/null
 
-go build -o ./build/_output/bin/operator-sdk ./vendor/github.com/operator-framework/operator-sdk/cmd/operator-sdk
+go build -o ./build/out/bin/operator-sdk ./vendor/github.com/operator-framework/operator-sdk/cmd/operator-sdk
 
-./build/_output/bin/operator-sdk $@
+./build/out/bin/operator-sdk $@
 
 popd > /dev/null
 


### PR DESCRIPTION
Followup PR for https://github.com/istio/operator/pull/307, since we're now using `build/out` as build output path.