### PR TITLE
watch all namespaces.

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -22,9 +22,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
followup PR for https://github.com/istio/operator/pull/356 
controller watches IstioControlPlane CRs in all namespaces instead of pod's namespace. 