### PR TITLE
add leader election namespace.

### DIFF
--- a/cmd/manager/server.go
+++ b/cmd/manager/server.go
@@ -80,8 +80,22 @@ func getWatchNamespace() (string, error) {
 	return ns, nil
 }
 
+// getLeaderElectionNamespace returns the namespace in which the leader election configmap will be created
+func getLeaderElectionNamespace() (string, error) {
+	ns, found := os.LookupEnv("LEADER_ELECTION_NAMESPACE")
+	if !found {
+		return "", fmt.Errorf("LEADER_ELECTION_NAMESPACE must be set")
+	}
+	return ns, nil
+}
+
 func run() {
-	namespace, err := getWatchNamespace()
+	watchNS, err := getWatchNamespace()
+	if err != nil {
+		log.Fatalf("Failed to get watch namespace: %v", err)
+	}
+
+	leaderElectionNS, err := getLeaderElectionNamespace()
 	if err != nil {
 		log.Fatalf("Failed to get watch namespace: %v", err)
 	}
@@ -94,12 +108,12 @@ func run() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
-		Namespace:          namespace,
+		Namespace:          watchNS,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 		// Workaround for https://github.com/kubernetes-sigs/controller-runtime/issues/321
 		MapperProvider:          drm.NewDynamicRESTMapper,
 		LeaderElection:          true,
-		LeaderElectionNamespace: namespace,
+		LeaderElectionNamespace: leaderElectionNS,
 		LeaderElectionID:        "istio-operator-lock",
 	})
 	if err != nil {

--- a/cmd/manager/server.go
+++ b/cmd/manager/server.go
@@ -97,7 +97,7 @@ func run() {
 
 	leaderElectionNS, err := getLeaderElectionNamespace()
 	if err != nil {
-		log.Fatalf("Failed to get watch namespace: %v", err)
+		log.Fatalf("Failed to get leader election namespace: %v", err)
 	}
 
 	// Get a config to talk to the apiserver

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -23,6 +23,10 @@ spec:
           env:
             - name: WATCH_NAMESPACE
               value: ""
+            - name: LEADER_ELECTION_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Add dedicated namespace for leader election namespace(default value is the namespace in which controller pod is running);
Because `WATCH_NAMESPACE` can be `""`, which means watching all namespaces for IstioControlPlane CR, while `LEADER_ELECTION_NAMESPACE` can not be `""`. 