### PR TITLE
Fix NPE

### DIFF
--- a/pkg/helmreconciler/rendering.go
+++ b/pkg/helmreconciler/rendering.go
@@ -240,7 +240,7 @@ func (h *HelmReconciler) ProcessObject(obj *unstructured.Unstructured) error {
 				log.Errorf("unexpected error occurred during postprocessing of updated resource: %s", err)
 			}
 		} else {
-			listenerErr := h.customizer.Listener().ResourceError(mutatedObj, err)
+			listenerErr := h.customizer.Listener().ResourceError(obj, err)
 			if listenerErr != nil {
 				log.Errorf("unexpected error occurred invoking ResourceError on listener: %s", listenerErr)
 			}


### PR DESCRIPTION
when CreatePatch fails, the mutatedObj will be nil. So use `obj` instead to prevent panic:
```
panic: runtime error: invalid memory address or nil pointer dereference

```