### PR TITLE
replace --yes flag with --skip-confirmation flag for better usage

### DIFF
--- a/cmd/mesh/root.go
+++ b/cmd/mesh/root.go
@@ -27,6 +27,8 @@ const (
 	setFlagHelpStr = `Set a value in IstioControlPlane CustomResource. e.g. --set policy.enabled=true.
 Overrides the corresponding path value in the selected profile or passed through IstioControlPlane CR
 customization file`
+	skipConfirmationFlagHelpStr = `skipConfirmation determines whether the user is prompted for confirmation. 
+If set to true, the user is not prompted and a Yes response is assumed in all cases.`
 	filenameFlagHelpStr = `Path to file containing IstioControlPlane CustomResource`
 )
 

--- a/prow/e2e_install.sh
+++ b/prow/e2e_install.sh
@@ -51,7 +51,7 @@ setup_kind_cluster "${NODE_IMAGE}"
 popd
 
 echo "installing istio with operator CLI"
-go run ./cmd/mesh.go manifest apply --yes
+go run ./cmd/mesh.go manifest apply --skip-confirmation
 
 function run-simple-base() {
     kubectl create ns "${NS}" || true


### PR DESCRIPTION
Here is the current `--skip-confirmation` behavior to replace the confusing `--yes` flag:
When `--skip-confirmation` flag is true, then, do not ask for confirmation; otherwise, ask for confirmation.
(1) `mesh manifest apply`
Ask for confirmation:
```
mesh manifest apply
Do you want to proceed? (y/N)
```
Since `--skip-confirmation` by default is `false`. If the user just type `enter`, then it will showing `Cancelled`. Since, the default answer is `No`.
(2) `mesh manifest apply --skip-confirmation` or  `mesh manifest apply --ask-confirm=true`
Do not ask for confirmation.
(3) `mesh manifest apply --skip-confirmation=false`
Ask for confirmation:
 ```
mesh manifest apply
Do you want to proceed? (y/N)
```
