### PR TITLE
Add vars for hub and tag that can be populated during build time

### DIFF
--- a/cmd/mesh/shared.go
+++ b/cmd/mesh/shared.go
@@ -28,6 +28,15 @@ const (
 	logFilePath = "./.mesh-cli.log"
 )
 
+var (
+	// HubValueFromBuild can be set to override the hub value in the base profile. It's applied after reading base
+	// profile from compiled in or file-based profiles, but before the user overlay or --set flag.
+	HubValueFromBuild = ""
+	// TagValueFromBuild can be set to override the tag value in the base profile. It's applied after reading base
+	// profile from compiled in or file-based profiles, but before the user overlay or --set flag.
+	TagValueFromBuild = ""
+)
+
 func initLogsOrExit(args *rootArgs) {
 	// Only the logs for the last command are of interest.
 	// Remove any previous log to avoid indefinite accumulation.


### PR DESCRIPTION
This addresses the issue of hub and tag being compiled in and committed before being pulled in before operator is imported as a module into istioctl.