### PR TITLE
Add offline support for version maps of `istioctl x upgrade`

### DIFF
--- a/cmd/mesh/manifest-versions.go
+++ b/cmd/mesh/manifest-versions.go
@@ -104,7 +104,7 @@ func getVersionCompatibleMap(versionsURI string, binVersion *goversion.Version,
 		}
 	}
 	if myVersionMap == nil {
-		return nil, fmt.Errorf("this operator version %v was not found in the global manifestVersions map", binVersion.String())
+		return nil, fmt.Errorf("this operator version %s was not found in the global manifestVersions map", binVersion.String())
 	}
 	return myVersionMap, nil
 }
@@ -116,14 +116,14 @@ func loadCompatibleMapFile(versionsURI string, l *logger) (b []byte, err error) 
 			return
 		}
 	}
-	l.logAndPrintf("Warning. Failed to retrieve the version map from the remote url: %v, error: %v."+
-		" Now fall back to the local file system.", versionsURI, err)
+	l.logAndPrintf("Warning: failed to retrieve the version map from the remote URL (%s): %s. " +
+		"Falling back to the local file: %s", versionsURI, err, versionsURI)
 
 	b, err = ioutil.ReadFile(versionsURI)
 	if err == nil {
 		return
 	}
-	l.logAndPrintf("Warning. Failed to retrieve the version map from the local file: %v, error: %v."+
-		" Now fall back to the built-in version map.", versionsURI, err)
+	l.logAndPrintf("Warning: failed to retrieve the version map from the local file (%s): %s. " +
+			"Falling back to the internal version map.", versionsURI, err)
 	return vfs.ReadFile("versions.yaml")
 }

--- a/cmd/mesh/manifest-versions.go
+++ b/cmd/mesh/manifest-versions.go
@@ -108,16 +108,15 @@ func getVersionCompatibleMap(versionsURI string, binVersion *goversion.Version,
 	return myVersionMap, nil
 }
 
-func loadCompatibleMapFile(versionsURI string, l *logger) (b []byte, err error) {
+func loadCompatibleMapFile(versionsURI string, l *logger) ([]byte, error) {
+	var err error
 	if util.IsHTTPURL(versionsURI) {
-		b, err = httprequest.Get(versionsURI)
-		if err == nil {
-			return
+		if b, err := httprequest.Get(versionsURI); err == nil {
+			return b, nil
 		}
 	} else {
-		b, err = ioutil.ReadFile(versionsURI)
-		if err == nil {
-			return
+		if b, err := ioutil.ReadFile(versionsURI); err == nil {
+			return b, nil
 		}
 	}
 

--- a/cmd/mesh/manifest-versions_test.go
+++ b/cmd/mesh/manifest-versions_test.go
@@ -74,7 +74,7 @@ func TestGetVersionCompatibleMap(t *testing.T) {
 				l:           l,
 			},
 			want: nil,
-			wantErr: fmt.Errorf("this operator version %v was not found in the global manifestVersions map",
+			wantErr: fmt.Errorf("this operator version %s was not found in the global manifestVersions map",
 				goVer131000.String()),
 		},
 	}

--- a/cmd/mesh/manifest-versions_test.go
+++ b/cmd/mesh/manifest-versions_test.go
@@ -1,0 +1,101 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mesh
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	goversion "github.com/hashicorp/go-version"
+
+	"istio.io/operator/pkg/version"
+)
+
+func TestGetVersionCompatibleMap(t *testing.T) {
+	type args struct {
+		versionsURI string
+		binVersion  *goversion.Version
+		l           *logger
+	}
+	goVer131000, _ := goversion.NewVersion("1.3.1000")
+	goVer132, _ := goversion.NewVersion("1.3.2")
+	scVer132, _ := goversion.NewConstraint(">=1.3.0,<=1.3.2")
+	rcVer132, _ := goversion.NewConstraint("1.3.2")
+	vm132 := &version.CompatibilityMapping{
+		OperatorVersion:          goVer132,
+		SupportedIstioVersions:   scVer132,
+		RecommendedIstioVersions: rcVer132,
+	}
+	l := newLogger(true, os.Stdout, os.Stderr)
+	tests := []struct {
+		name    string
+		args    args
+		want    *version.CompatibilityMapping
+		wantErr error
+	}{
+		{
+			name: "built-in version map",
+			args: args{
+				versionsURI: "__nonexistent-versions.yaml",
+				binVersion:  goVer132,
+				l:           l,
+			},
+			want:    vm132,
+			wantErr: nil,
+		},
+		{
+			name: "read from github",
+			args: args{
+				versionsURI: versionsMapURL,
+				binVersion:  goVer132,
+				l:           l,
+			},
+			want:    vm132,
+			wantErr: nil,
+		},
+		{
+			name: "go version not found in version map",
+			args: args{
+				versionsURI: "__nonexistent-versions.yaml",
+				binVersion:  goVer131000,
+				l:           l,
+			},
+			want: nil,
+			wantErr: fmt.Errorf("this operator version %v was not found in the global manifestVersions map",
+				goVer131000.String()),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := getVersionCompatibleMap(tt.args.versionsURI, tt.args.binVersion, tt.args.l)
+			if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", tt.want) {
+				t.Errorf("got: %v, want: %v", got, tt.want)
+			}
+			if errToString(gotErr) != errToString(tt.wantErr) {
+				t.Errorf("gotErr: %v, wantErr: %v", gotErr, tt.wantErr)
+			}
+		})
+	}
+}
+
+// errToString returns the string representation of err and the empty string if
+// err is nil.
+func errToString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/cmd/mesh/testdata/manifest-versions/input/versions.yaml
+++ b/cmd/mesh/testdata/manifest-versions/input/versions.yaml
@@ -1,0 +1,15 @@
+- operatorVersion: 1.3.0
+  supportedIstioVersions: 1.3.0
+  recommendedIstioVersions: 1.3.0
+- operatorVersion: 1.3.1
+  supportedIstioVersions: ">=1.3.0,<=1.3.1"
+  recommendedIstioVersions: 1.3.1
+- operatorVersion: 1.3.2
+  supportedIstioVersions: ">=1.3.0,<=1.3.2"
+  recommendedIstioVersions: 1.3.2
+- operatorVersion: 1.3.3
+  supportedIstioVersions: ">=1.3.0,<=1.3.3"
+  recommendedIstioVersions: 1.3.3
+- operatorVersion: 1.4.0
+  supportedIstioVersions: ">=1.3.3, <1.6"
+  recommendedIstioVersions: 1.4.0

--- a/cmd/mesh/upgrade.go
+++ b/cmd/mesh/upgrade.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ghodss/yaml"
 	goversion "github.com/hashicorp/go-version"
 	"github.com/spf13/cobra"
+
 	"istio.io/pkg/log"
 
 	"istio.io/operator/pkg/compare"
@@ -275,11 +276,14 @@ func checkSupportedVersions(cur, tar, versionsURI string, l *logger) error {
 		return fmt.Errorf("failed to parse the target version: %v", tar)
 	}
 
-	compatibleMap := getVersionCompatibleMap(versionsURI, tarGoVersion, l)
+	compatibleMap, err := getVersionCompatibleMap(versionsURI, tarGoVersion, l)
+	if err != nil {
+		return err
+	}
 
 	curGoVersion, err := goversion.NewVersion(cur)
 	if err != nil {
-		return fmt.Errorf("failed to parse the current version: %v", cur)
+		return fmt.Errorf("failed to parse the current version: %v, error: %v", cur, err)
 	}
 
 	if !compatibleMap.SupportedIstioVersions.Check(curGoVersion) {

--- a/cmd/mesh/upgrade.go
+++ b/cmd/mesh/upgrade.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ghodss/yaml"
 	goversion "github.com/hashicorp/go-version"
 	"github.com/spf13/cobra"
+	"istio.io/pkg/log"
 
 	"istio.io/operator/pkg/compare"
 	"istio.io/operator/pkg/hooks"
@@ -95,7 +96,7 @@ func UpgradeCmd() *cobra.Command {
 			initLogsOrExit(rootArgs)
 			err := upgrade(rootArgs, macArgs, l)
 			if err != nil {
-				l.logAndPrintf("Error: %v\n", err)
+				log.Infof("Error: %v\n", err)
 			}
 			return err
 		},

--- a/cmd/mesh/upgrade.go
+++ b/cmd/mesh/upgrade.go
@@ -301,7 +301,7 @@ func retrieveControlPlaneVersion(kubeClient manifest.ExecClient, istioNamespace 
 	}
 
 	for _, remote := range cv {
-		l.logAndPrintf("Control Plane - %s pod - version: %s", remote.Component, remote.Version)
+		l.logAndPrintf("Control Plane - %v", remote)
 	}
 	l.logAndPrint("")
 
@@ -333,8 +333,8 @@ func waitUpgradeComplete(kubeClient manifest.ExecClient, istioNamespace string, 
 		}
 		for _, remote := range cv {
 			if targetVer != remote.Version {
-				l.logAndPrintf("Control Plane - %s pod - version %s does not match the target version %s",
-					remote.Component, remote.Version, targetVer)
+				l.logAndPrintf("Control Plane - %v does not match the target version %s",
+					remote, targetVer)
 			}
 		}
 	}

--- a/pkg/manifest/client.go
+++ b/pkg/manifest/client.go
@@ -90,7 +90,7 @@ func (client *Client) GetIstioVersions(namespace string) ([]ComponentVersion, er
 
 		server := ComponentVersion{
 			Component: component,
-			Pod: pod,
+			Pod:       pod,
 		}
 
 		pv := ""

--- a/pkg/manifest/client.go
+++ b/pkg/manifest/client.go
@@ -34,6 +34,12 @@ type Client struct {
 type ComponentVersion struct {
 	Component string
 	Version   string
+	Pod       v1.Pod
+}
+
+func (cv ComponentVersion) String() string {
+	return fmt.Sprintf("%s pod - %s - version: %s",
+		cv.Component, cv.Pod.GetName(), cv.Version)
 }
 
 // ExecClient is an interface for remote execution
@@ -82,7 +88,11 @@ func (client *Client) GetIstioVersions(namespace string) ([]ComponentVersion, er
 			component = pod.Labels["istio-mixer-type"]
 		}
 
-		server := ComponentVersion{Component: component}
+		server := ComponentVersion{
+			Component: component,
+			Pod: pod,
+		}
+
 		pv := ""
 		for _, c := range pod.Spec.Containers {
 			cv, err := parseTag(c.Image)

--- a/pkg/vfs/assets.gen.go
+++ b/pkg/vfs/assets.gen.go
@@ -3,7 +3,6 @@
 // ../../data/charts/crds/Chart.yaml
 // ../../data/charts/crds/files/crd-10.yaml
 // ../../data/charts/crds/files/crd-11.yaml
-// ../../data/charts/crds/files/crd-12.yaml
 // ../../data/charts/crds/files/crd-14.yaml
 // ../../data/charts/crds/files/crd-certmanager-10.yaml
 // ../../data/charts/crds/files/crd-certmanager-11.yaml
@@ -157,7 +156,6 @@
 // ../../data/charts/istio-telemetry/prometheus/templates/deployment.yaml
 // ../../data/charts/istio-telemetry/prometheus/templates/destination-rule.yaml
 // ../../data/charts/istio-telemetry/prometheus/templates/ingress.yaml
-// ../../data/charts/istio-telemetry/prometheus/templates/inrgess.yaml
 // ../../data/charts/istio-telemetry/prometheus/templates/service.yaml
 // ../../data/charts/istio-telemetry/prometheus/templates/serviceaccount.yaml
 // ../../data/charts/istio-telemetry/prometheus/templates/tests/test-prometheus-connection.yaml
@@ -983,47 +981,6 @@ func chartsCrdsFilesCrd11Yaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "charts/crds/files/crd-11.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
-	a := &asset{bytes: bytes, info: info}
-	return a, nil
-}
-
-var _chartsCrdsFilesCrd12Yaml = []byte(`kind: CustomResourceDefinition
-apiVersion: apiextensions.k8s.io/v1beta1
-metadata:
-  name: authorizationpolicies.rbac.istio.io
-  labels:
-    app: istio-pilot
-    istio: rbac
-    heritage: Tiller
-    release: istio
-spec:
-  group: rbac.istio.io
-  names:
-    kind: AuthorizationPolicy
-    plural: authorizationpolicies
-    singular: authorizationpolicy
-    categories:
-      - istio-io
-      - rbac-istio-io
-  scope: Namespaced
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
----
-`)
-
-func chartsCrdsFilesCrd12YamlBytes() ([]byte, error) {
-	return _chartsCrdsFilesCrd12Yaml, nil
-}
-
-func chartsCrdsFilesCrd12Yaml() (*asset, error) {
-	bytes, err := chartsCrdsFilesCrd12YamlBytes()
-	if err != nil {
-		return nil, err
-	}
-
-	info := bindataFileInfo{name: "charts/crds/files/crd-12.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -28220,61 +28177,6 @@ func chartsIstioTelemetryPrometheusTemplatesIngressYaml() (*asset, error) {
 	return a, nil
 }
 
-var _chartsIstioTelemetryPrometheusTemplatesInrgessYaml = []byte(`{{- if .Values.prometheus.ingress.enabled -}}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: prometheus
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: prometheus
-    release: {{ .Release.Name }}
-  annotations:
-    {{- range $key, $value := .Values.prometheus.ingress.annotations }}
-      {{ $key }}: {{ $value | quote }}
-    {{- end }}
-spec:
-  rules:
-{{- if .Values.prometheus.ingress.hosts }}
-    {{- range $host := .Values.prometheus.ingress.hosts }}
-    - host: {{ $host }}
-      http:
-        paths:
-          - path: {{ if $.Values.prometheus.contextPath }} {{ $.Values.prometheus.contextPath }} {{ else }} / {{ end }}
-            backend:
-              serviceName: prometheus
-              servicePort: 9090
-    {{- end -}}
-{{- else }}
-    - http:
-        paths:
-          - path: {{ if .Values.prometheus.contextPath }} {{ .Values.prometheus.contextPath }} {{ else }} / {{ end }}
-            backend:
-              serviceName: prometheus
-              servicePort: 9090
-{{- end }}
-  {{- if .Values.prometheus.ingress.tls }}
-  tls:
-{{ toYaml .Values.prometheus.ingress.tls | indent 4 }}
-  {{- end -}}
-{{- end -}}
-`)
-
-func chartsIstioTelemetryPrometheusTemplatesInrgessYamlBytes() ([]byte, error) {
-	return _chartsIstioTelemetryPrometheusTemplatesInrgessYaml, nil
-}
-
-func chartsIstioTelemetryPrometheusTemplatesInrgessYaml() (*asset, error) {
-	bytes, err := chartsIstioTelemetryPrometheusTemplatesInrgessYamlBytes()
-	if err != nil {
-		return nil, err
-	}
-
-	info := bindataFileInfo{name: "charts/istio-telemetry/prometheus/templates/inrgess.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
-	a := &asset{bytes: bytes, info: info}
-	return a, nil
-}
-
 var _chartsIstioTelemetryPrometheusTemplatesServiceYaml = []byte(`apiVersion: v1
 kind: Service
 metadata:
@@ -33538,7 +33440,6 @@ var _bindata = map[string]func() (*asset, error){
 	"charts/crds/Chart.yaml": chartsCrdsChartYaml,
 	"charts/crds/files/crd-10.yaml": chartsCrdsFilesCrd10Yaml,
 	"charts/crds/files/crd-11.yaml": chartsCrdsFilesCrd11Yaml,
-	"charts/crds/files/crd-12.yaml": chartsCrdsFilesCrd12Yaml,
 	"charts/crds/files/crd-14.yaml": chartsCrdsFilesCrd14Yaml,
 	"charts/crds/files/crd-certmanager-10.yaml": chartsCrdsFilesCrdCertmanager10Yaml,
 	"charts/crds/files/crd-certmanager-11.yaml": chartsCrdsFilesCrdCertmanager11Yaml,
@@ -33692,7 +33593,6 @@ var _bindata = map[string]func() (*asset, error){
 	"charts/istio-telemetry/prometheus/templates/deployment.yaml": chartsIstioTelemetryPrometheusTemplatesDeploymentYaml,
 	"charts/istio-telemetry/prometheus/templates/destination-rule.yaml": chartsIstioTelemetryPrometheusTemplatesDestinationRuleYaml,
 	"charts/istio-telemetry/prometheus/templates/ingress.yaml": chartsIstioTelemetryPrometheusTemplatesIngressYaml,
-	"charts/istio-telemetry/prometheus/templates/inrgess.yaml": chartsIstioTelemetryPrometheusTemplatesInrgessYaml,
 	"charts/istio-telemetry/prometheus/templates/service.yaml": chartsIstioTelemetryPrometheusTemplatesServiceYaml,
 	"charts/istio-telemetry/prometheus/templates/serviceaccount.yaml": chartsIstioTelemetryPrometheusTemplatesServiceaccountYaml,
 	"charts/istio-telemetry/prometheus/templates/tests/test-prometheus-connection.yaml": chartsIstioTelemetryPrometheusTemplatesTestsTestPrometheusConnectionYaml,
@@ -33803,7 +33703,6 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"files": &bintree{nil, map[string]*bintree{
 				"crd-10.yaml": &bintree{chartsCrdsFilesCrd10Yaml, map[string]*bintree{}},
 				"crd-11.yaml": &bintree{chartsCrdsFilesCrd11Yaml, map[string]*bintree{}},
-				"crd-12.yaml": &bintree{chartsCrdsFilesCrd12Yaml, map[string]*bintree{}},
 				"crd-14.yaml": &bintree{chartsCrdsFilesCrd14Yaml, map[string]*bintree{}},
 				"crd-certmanager-10.yaml": &bintree{chartsCrdsFilesCrdCertmanager10Yaml, map[string]*bintree{}},
 				"crd-certmanager-11.yaml": &bintree{chartsCrdsFilesCrdCertmanager11Yaml, map[string]*bintree{}},
@@ -34014,7 +33913,6 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"deployment.yaml": &bintree{chartsIstioTelemetryPrometheusTemplatesDeploymentYaml, map[string]*bintree{}},
 					"destination-rule.yaml": &bintree{chartsIstioTelemetryPrometheusTemplatesDestinationRuleYaml, map[string]*bintree{}},
 					"ingress.yaml": &bintree{chartsIstioTelemetryPrometheusTemplatesIngressYaml, map[string]*bintree{}},
-					"inrgess.yaml": &bintree{chartsIstioTelemetryPrometheusTemplatesInrgessYaml, map[string]*bintree{}},
 					"service.yaml": &bintree{chartsIstioTelemetryPrometheusTemplatesServiceYaml, map[string]*bintree{}},
 					"serviceaccount.yaml": &bintree{chartsIstioTelemetryPrometheusTemplatesServiceaccountYaml, map[string]*bintree{}},
 					"tests": &bintree{nil, map[string]*bintree{


### PR DESCRIPTION
 Fall back to using the built-in version map if the remote one is not available. + some minor fixes on output.

Version maps specify which versions are supported from which operator. The source of truth is master but we need a local copy built into operator for offline upgrade cases.
Resolve: https://github.com/istio/istio/issues/17912