### PR TITLE
WIP: Rationalize makefile usage of /home

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,9 @@ ifeq ($(BUILD_WITH_CONTAINER),1)
 export TARGET_OUT = /work/out/$(TARGET_ARCH)_$(TARGET_OS)
 CONTAINER_CLI ?= docker
 DOCKER_SOCKET_MOUNT ?= -v /var/run/docker.sock:/var/run/docker.sock
-IMG ?= gcr.io/istio-testing/build-tools:2019-10-11T13-37-52
+IMG ?= gcr.io/istio-testing/build-tools:latest
 UID = $(shell id -u)
+GID = `grep docker /etc/group | cut -f3 -d:`
 PWD = $(shell pwd)
 
 $(info Building with the build container: $(IMG).)
@@ -67,7 +68,7 @@ $(info Building with the build container: $(IMG).)
 # the path of the file.
 TIMEZONE=`readlink $(READLINK_FLAGS) /etc/localtime | sed -e 's/^.*zoneinfo\///'`
 
-RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):docker --rm \
+RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):$(GID) --rm \
 	-e IN_BUILD_CONTAINER="$(BUILD_WITH_CONTAINER)" \
 	-e TZ="$(TIMEZONE)" \
 	-e TARGET_ARCH="$(TARGET_ARCH)" \
@@ -81,6 +82,8 @@ RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):docker --rm \
 	--mount type=bind,source="$(PWD)",destination="/work" \
 	--mount type=volume,source=go,destination="/go" \
 	--mount type=volume,source=gocache,destination="/gocache" \
+	--mount type=bind,source="$(HOME)/.docker",destination="/config/.docker" \
+	--mount type=bind,source="$(HOME)/.config/gcloud",destination="/config/.config/gcloud" \
 	-w /work $(IMG)
 else
 $(info Building with your local toolchain.)


### PR DESCRIPTION
This bindmounts config secrets contents into the container and then
uses those secrets by copying them to the correct location within the
containers environment. The one open question about this model is whether
this will work with prow given that an entrypoint is used.