### PR TITLE
update CRD correct links and add desp

### DIFF
--- a/deploy/crds/istio_v1alpha2_istiocontrolplane_crd.yaml
+++ b/deploy/crds/istio_v1alpha2_istiocontrolplane_crd.yaml
@@ -38,7 +38,7 @@ spec:
             More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
           type: object
         status:
-          description: 'Status describes each of istio control plane component's status at the current time.
+          description: 'Status describes each of istio control plane component status at the current time.
             0 means NONE, 1 means UPDATING, 2 means HEALTHY, 3 means ERROR, 4 means RECONCILING.
             More info: https://github.com/istio/operator/blob/master/pkg/apis/istio/v1alpha2/v1alpha2.pb.html &
             https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'

--- a/deploy/crds/istio_v1alpha2_istiocontrolplane_crd.yaml
+++ b/deploy/crds/istio_v1alpha2_istiocontrolplane_crd.yaml
@@ -20,18 +20,28 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
+          description: 'Metadata about the istio control plane resource.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata'
           type: object
         spec:
+          description: 'Specification of the desired state of the istio control plane resource.
+            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
           type: object
         status:
+          description: 'Status describes each of istio control plane component's status at the current time.
+            0 means NONE, 1 means UPDATING, 2 means HEALTHY, 3 means ERROR, 4 means RECONCILING.
+            More info: https://github.com/istio/operator/blob/master/pkg/apis/istio/v1alpha2/v1alpha2.pb.html &
+            https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
           type: object
   versions:
   - name: v1alpha2


### PR DESCRIPTION
One of our users ask us what does status mean, thus triggered the PR. :)  Note the few existing links lead to 404.

```
status:
  status:
    Citadel:
      status: 2
    EgressGateway:
      status: 2
    Galley:
      status: 2
    Grafana:
      status: 2
    IngressGateway:
      status: 2
    Injector:
      status: 2
    Kiali:
      status: 2
    Pilot:
      status: 2
    Policy:
      status: 2
    Prometheus:
      status: 2
    Telemetry:
      status: 2
    Tracing:
      status: 2
    crds:
      status: 2
```