### PR TITLE
Exclude the overridden values when comparing the old with the new ones.

### DIFF
--- a/cmd/mesh/profile-dump.go
+++ b/cmd/mesh/profile-dump.go
@@ -177,7 +177,7 @@ func genICPS(inFilename, profile, setOverlayYAML string, force bool, l *logger) 
 	return finalYAML, finalICPS, nil
 }
 
-func genOverlayICPS(filename string) (string, *v1alpha2.IstioControlPlaneSpec, error) {
+func genOverlayICPS(filename string, force bool) (string, *v1alpha2.IstioControlPlaneSpec, error) {
 	if filename == "" {
 		return "", nil, nil
 	}
@@ -186,7 +186,7 @@ func genOverlayICPS(filename string) (string, *v1alpha2.IstioControlPlaneSpec, e
 	if err != nil {
 		return "", nil, fmt.Errorf("could not read from file %s: %s", filename, err)
 	}
-	overlayICPS, _, err := unmarshalAndValidateICP(string(b))
+	overlayICPS, _, err := unmarshalAndValidateICP(string(b), force)
 	if err != nil {
 		return "", nil, err
 	}

--- a/cmd/mesh/upgrade.go
+++ b/cmd/mesh/upgrade.go
@@ -16,25 +16,18 @@ package mesh
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/ghodss/yaml"
 	goversion "github.com/hashicorp/go-version"
 	"github.com/spf13/cobra"
 
-	"istio.io/operator/pkg/apis/istio/v1alpha2"
-	"istio.io/operator/pkg/component/component"
-	"istio.io/operator/pkg/translate"
-
-	"istio.io/pkg/log"
-
 	"istio.io/operator/pkg/compare"
 	"istio.io/operator/pkg/hooks"
 	"istio.io/operator/pkg/manifest"
 	opversion "istio.io/operator/version"
+	"istio.io/pkg/log"
 )
 
 const (
@@ -115,33 +108,6 @@ func UpgradeCmd() *cobra.Command {
 	addFlags(cmd, rootArgs)
 	addUpgradeFlags(cmd, macArgs)
 	return cmd
-}
-
-func genOverlayICPS(filename string) (string, *v1alpha2.IstioControlPlaneSpec, error) {
-	if strings.TrimSpace(filename) == "" {
-		return "", nil, nil
-	}
-
-	b, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return "", nil, fmt.Errorf("could not read from file %s: %s", filename, err)
-	}
-	overlayICPS, _, err := unmarshalAndValidateICP(string(b))
-	if err != nil {
-		return "", nil, err
-	}
-
-	t, err := translate.NewTranslator(opversion.OperatorBinaryVersion.MinorVersion)
-	if err != nil {
-		return "", nil, err
-	}
-
-	overlayYAML, err := component.TranslateHelmValues(overlayICPS, t, "")
-	if err != nil {
-		return "", nil, err
-	}
-
-	return overlayYAML, overlayICPS, nil
 }
 
 // upgrade is the main function for Upgrade command

--- a/cmd/mesh/upgrade.go
+++ b/cmd/mesh/upgrade.go
@@ -50,6 +50,8 @@ const (
 type upgradeArgs struct {
 	// inFilename is the path to the input IstioControlPlane CR.
 	inFilename string
+	// versionsURI is a URI pointing to a YAML formatted versions mapping.
+	versionsURI string
 	// kubeConfigPath is the path to kube config file.
 	kubeConfigPath string
 	// context is the cluster context in the kube config.
@@ -60,8 +62,6 @@ type upgradeArgs struct {
 	skipConfirmation bool
 	// force means directly applying the upgrade without eligibility checks.
 	force bool
-	// versionsURI is a URI pointing to a YAML formatted versions mapping.
-	versionsURI string
 	// showOverrides shows all changed values even if they are specified in inFilename.
 	showOverrides bool
 }
@@ -70,6 +70,8 @@ type upgradeArgs struct {
 func addUpgradeFlags(cmd *cobra.Command, args *upgradeArgs) {
 	cmd.PersistentFlags().StringVarP(&args.inFilename, "filename",
 		"f", "", "Path to file containing IstioControlPlane CustomResource")
+	cmd.PersistentFlags().StringVarP(&args.versionsURI, "versionsURI", "u",
+		versionsMapURL, "URI for operator versions to Istio versions map")
 	cmd.PersistentFlags().StringVarP(&args.kubeConfigPath, "kubeconfig",
 		"c", "", "Path to kube config")
 	cmd.PersistentFlags().StringVar(&args.context, "context", "",
@@ -86,8 +88,6 @@ func addUpgradeFlags(cmd *cobra.Command, args *upgradeArgs) {
 	cmd.PersistentFlags().BoolVar(&args.force, "force", false,
 		"Apply the upgrade without eligibility checks and testing for changes "+
 			"in profile default values")
-	cmd.PersistentFlags().StringVarP(&args.versionsURI, "versionsURI", "u",
-		versionsMapURL, "URI for operator versions to Istio versions map")
 }
 
 // Upgrade command upgrades Istio control plane in-place with eligibility checks

--- a/cmd/mesh/upgrade.go
+++ b/cmd/mesh/upgrade.go
@@ -17,6 +17,7 @@ package mesh
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -113,6 +114,7 @@ func UpgradeCmd() *cobra.Command {
 // upgrade is the main function for Upgrade command
 func upgrade(rootArgs *rootArgs, args *upgradeArgs, l *logger) (err error) {
 	l.logAndPrintf("Client - istioctl version: %s\n", opversion.OperatorVersionString)
+	args.inFilename = strings.TrimSpace(args.inFilename)
 
 	// Generates values for args.inFilename ICP specs yaml
 	targetValues, err := genProfile(true, args.inFilename, "",
@@ -174,7 +176,6 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l *logger) (err error) {
 	if args.showOverrides {
 		checkUpgradeValues(currentValues, targetValues, "", l)
 	} else {
-		// Generates overridden values from args.inFilename
 		overrideValues, _, err := genOverlayICPS(args.inFilename)
 		if err != nil {
 			return fmt.Errorf("failed to generate override values from file: %v, error: %v", args.inFilename, err)

--- a/cmd/mesh/upgrade.go
+++ b/cmd/mesh/upgrade.go
@@ -169,6 +169,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l *logger) (err error) {
 	}
 	l.logAndPrintf("Upgrade version check passed: %v -> %v.\n", currentVersion, targetVersion)
 
+	// Read the overridden values from args.inFilename
 	overrideValues, _, err := genOverlayICPS(args.inFilename)
 	if err != nil {
 		return fmt.Errorf("failed to generate override values from file: %v, error: %v", args.inFilename, err)

--- a/cmd/mesh/upgrade.go
+++ b/cmd/mesh/upgrade.go
@@ -170,7 +170,7 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l *logger) (err error) {
 	l.logAndPrintf("Upgrade version check passed: %v -> %v.\n", currentVersion, targetVersion)
 
 	// Read the overridden values from args.inFilename
-	overrideValues, _, err := genOverlayICPS(args.inFilename)
+	overrideValues, _, err := genOverlayICPS(args.inFilename, args.force)
 	if err != nil {
 		return fmt.Errorf("failed to generate override values from file: %v, error: %v", args.inFilename, err)
 	}

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -181,8 +181,8 @@ func genYamlIgnoreOpt(yamlStr string) (cmp.Option, error) {
 	}
 	return cmp.FilterPath(func(curPath cmp.Path) bool {
 		up := pathToStringList(curPath)
-		_, found, _ := name.GetFromTreePath(tree, up)
-		return found
+		treeNode, found, _ := name.GetFromTreePath(tree, up)
+		return found && tpath.IsLeafNode(treeNode)
 	}, cmp.Ignore()), nil
 }
 

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -179,28 +179,22 @@ func genYamlIgnoreOpt(yamlStr string) (cmp.Option, error) {
 	}
 	return cmp.FilterPath(func(curPath cmp.Path) bool {
 		up := pathToStringList(curPath)
-		found, _ := IsPathInTree(tree, up)
+		found, _ := isPathInTree(tree, up)
 		return found
 	}, cmp.Ignore()), nil
 }
 
-func IsPathInTree(tree map[string]interface{}, path []string) (bool, error) {
-	// Clone a slice: https://github.com/go101/go101/wiki
-	remainPath := append(path[:0:0], path...)
-	return isPathInTree(tree, remainPath)
-}
-
-func isPathInTree(tree map[string]interface{}, remainPath []string) (bool, error) {
-	if len(remainPath) == 0 {
+func isPathInTree(tree map[string]interface{}, path []string) (bool, error) {
+	if len(path) == 0 {
 		return false, nil
 	}
 	for key, val := range tree {
-		if key == remainPath[0] {
+		if key == path[0] {
 			// found it
-			if len(remainPath) == 1 {
+			if len(path) == 1 {
 				return true, nil
 			}
-			remainPath = remainPath[1:]
+			remainPath := path[1:]
 			switch node := val.(type) {
 			case map[string]interface{}:
 				return isPathInTree(node, remainPath)

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -187,10 +187,10 @@ func genYamlIgnoreOpt(yamlStr string) (cmp.Option, error) {
 func IsPathInTree(tree map[string]interface{}, path []string) (bool, error) {
 	// Clone a slice: https://github.com/go101/go101/wiki
 	remainPath := append(path[:0:0], path...)
-	return isPathInTree(tree, path, remainPath)
+	return isPathInTree(tree, remainPath)
 }
 
-func isPathInTree(tree map[string]interface{}, path []string, remainPath []string) (bool, error) {
+func isPathInTree(tree map[string]interface{}, remainPath []string) (bool, error) {
 	if len(remainPath) == 0 {
 		return false, nil
 	}
@@ -203,14 +203,14 @@ func isPathInTree(tree map[string]interface{}, path []string, remainPath []strin
 			remainPath = remainPath[1:]
 			switch node := val.(type) {
 			case map[string]interface{}:
-				return isPathInTree(node, path, remainPath)
+				return isPathInTree(node, remainPath)
 			case []interface{}:
 				for _, newNode := range node {
 					newMap, ok := newNode.(map[string]interface{})
 					if !ok {
 						return false, fmt.Errorf("fail to convert []interface{} to map[string]interface{}")
 					}
-					found, err := isPathInTree(newMap, path, remainPath)
+					found, err := isPathInTree(newMap, remainPath)
 					if found && err == nil {
 						return found, nil
 					}

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -683,12 +683,12 @@ metadata:
 
 func TestYAMLCmpWithIgnoreTree(t *testing.T) {
 	tests := []struct {
-		desc string
-		a    string
-		b    string
-		i    []string
-		y    string
-		want interface{}
+		desc   string
+		a      string
+		b      string
+		ignore []string
+		mask   string
+		want   interface{}
 	}{
 		{
 			desc: "ignore overrides",
@@ -714,7 +714,7 @@ metadata:
 spec:
   hub: docker.io/istio
   tag: 1.3.3`,
-			y: `apiVersion: install.istio.io/v1alpha2
+			mask: `apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane
 spec:
   hub: docker.io/istio
@@ -733,7 +733,7 @@ spec:
   labels:
     app: istio-ingressgateway
     release: istio-1.3.2`,
-			y: `metadata:
+			mask: `metadata:
   labels:
     release: istio-1.3.3`,
 			want: ``,
@@ -762,7 +762,7 @@ metadata:
 spec:
   hub: docker.io/istio
   tag: 1.3.3`,
-			y: `apiVersion: install.istio.io/v1alpha2
+			mask: `apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane`,
 			want: `spec:
   hub: gcr.io/istio-testing -> docker.io/istio
@@ -772,7 +772,7 @@ kind: IstioControlPlane`,
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			if got, want := YAMLCmpWithIgnore(tt.a, tt.b, tt.i, tt.y), tt.want; !(got == want) {
+			if got, want := YAMLCmpWithIgnore(tt.a, tt.b, tt.ignore, tt.mask), tt.want; !(got == want) {
 				t.Errorf("%s: got:%v, want:%v", tt.desc, got, want)
 			}
 		})

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -683,96 +683,90 @@ metadata:
 
 func TestYAMLCmpWithIgnoreTree(t *testing.T) {
 	tests := []struct {
-		desc   string
-		a      string
-		b      string
-		ignore []string
-		mask   string
-		want   interface{}
+		desc string
+		a    string
+		b    string
+		mask string
+		want interface{}
 	}{
 		{
-			desc: "ignore overrides",
-			a: `apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
-  labels:
-    app: istio-ingressgateway
-    release: istio
-spec:
-  hub: gcr.io/istio-testing
-  tag: latest`,
-			b: `apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
-  labels:
-    app: istio-ingressgateway
-    release: istio
-spec:
-  hub: docker.io/istio
-  tag: 1.3.3`,
-			mask: `apiVersion: install.istio.io/v1alpha2
-kind: IstioControlPlane
-spec:
-  hub: docker.io/istio
-  tag: 1.3.3`,
+			desc: "ignore masked",
+			a: `
+ak: av
+bk:
+  b1k: b1v
+  b2k: b2v
+`,
+			b: `
+ak: av
+bk:
+  b1k: b1v-changed
+  b2k: b2v-changed
+`,
+			mask: `
+bk:
+  b1k: ignored
+  b2k: ignored
+`,
 			want: ``,
 		},
 		{
-			desc: "ignore nested overrides",
-			a: `metadata:
-  name: istio-ingressgateway
-  labels:
-    app: istio-ingressgateway
-    release: istio-1.3.3`,
-			b: `metadata:
-  name: istio-ingressgateway
-  labels:
-    app: istio-ingressgateway
-    release: istio-1.3.2`,
-			mask: `metadata:
-  labels:
-    release: istio-1.3.3`,
-			want: ``,
+			desc: "ignore nested masked",
+			a: `
+ak: av
+bk:
+  bbk:
+    b1k: b1v
+    b2k: b2v
+`,
+			b: `
+ak: av
+bk:
+  bbk:
+    b1k: b1v-changed
+    b2k: b2v-changed
+`,
+			mask: `
+bk:
+  bbk:
+    b1k: ignored
+`,
+			want: `bk:
+  bbk:
+    b2k: b2v -> b2v-changed
+`,
 		},
 		{
-			desc: "not ignore non-overrides",
-			a: `apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
-  labels:
-    app: istio-ingressgateway
-    release: istio
-spec:
-  hub: gcr.io/istio-testing
-  tag: latest`,
-			b: `apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
-  labels:
-    app: istio-ingressgateway
-    release: istio
-spec:
-  hub: docker.io/istio
-  tag: 1.3.3`,
-			mask: `apiVersion: install.istio.io/v1alpha2
-kind: IstioControlPlane`,
-			want: `spec:
-  hub: gcr.io/istio-testing -> docker.io/istio
-  tag: latest -> 1.3.3
+			desc: "not ignore non-masked",
+			a: `
+ak: av
+bk:
+  bbk:
+    b1k: b1v
+    b2k: b2v
+`,
+			b: `
+ak: av
+bk:
+  bbk:
+    b1k: b1v-changed
+    b2k: b2v
+`,
+			mask: `
+bk:
+  bbk:
+    b1k:
+      bbb1k: ignored
+`,
+			want: `bk:
+  bbk:
+    b1k: b1v -> b1v-changed
 `,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			if got, want := YAMLCmpWithIgnore(tt.a, tt.b, tt.ignore, tt.mask), tt.want; !(got == want) {
+			if got, want := YAMLCmpWithIgnore(tt.a, tt.b, nil, tt.mask), tt.want; !(got == want) {
 				t.Errorf("%s: got:%v, want:%v", tt.desc, got, want)
 			}
 		})

--- a/pkg/object/objects.go
+++ b/pkg/object/objects.go
@@ -527,7 +527,7 @@ func manifestDiff(aom, bom map[string]*K8sObject, im map[string]string, verbose 
 			diff = util.YAMLDiff(string(ay), string(by))
 		} else {
 			ignorePaths := objectIgnorePaths(ak, im)
-			diff = compare.YAMLCmpWithIgnore(string(ay), string(by), ignorePaths)
+			diff = compare.YAMLCmpWithIgnore(string(ay), string(by), ignorePaths, "")
 		}
 
 		if diff != "" {

--- a/pkg/object/objects.go
+++ b/pkg/object/objects.go
@@ -32,8 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 
-	"istio.io/operator/pkg/util"
 	"istio.io/operator/pkg/compare"
+	"istio.io/operator/pkg/util"
 	"istio.io/pkg/log"
 )
 

--- a/pkg/object/objects.go
+++ b/pkg/object/objects.go
@@ -33,7 +33,6 @@ import (
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"istio.io/operator/pkg/util"
-
 	"istio.io/operator/pkg/compare"
 	"istio.io/pkg/log"
 )

--- a/pkg/tpath/tpath.go
+++ b/pkg/tpath/tpath.go
@@ -224,6 +224,15 @@ func WritePathContext(nc *PathContext, value interface{}) error {
 	return nil
 }
 
+func IsLeafNode(treeNode interface{}) bool {
+	switch treeNode.(type) {
+	case map[string]interface{}, []interface{}:
+		return false
+	default:
+		return true
+	}
+}
+
 // TODO Merge this into existing WritePathContext method (istio/istio#15494)
 // DeleteFromTree sets value at path of input untyped tree to nil
 func DeleteFromTree(valueTree map[string]interface{}, path util.Path, remainPath util.Path) (bool, error) {


### PR DESCRIPTION
Resolve: https://github.com/istio/istio/issues/17916

When user explicitly inputs an IstioControlPlaneSpec CR file, do not output the overridden value changes by default. Also add --show-overrides flag to show all changed values.