### PR TITLE
Properly format yaml messages

### DIFF
--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -110,4 +111,4 @@ rules:
   - serviceaccounts
   verbs:
   - '*'
----
+...

--- a/deploy/clusterrole_binding.yaml
+++ b/deploy/clusterrole_binding.yaml
@@ -1,3 +1,4 @@
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -10,4 +11,4 @@ roleRef:
   kind: ClusterRole
   name: istio-operator
   apiGroup: rbac.authorization.k8s.io
----
+...

--- a/deploy/crds/istio_v1alpha2_istiocontrolplane_cr.yaml
+++ b/deploy/crds/istio_v1alpha2_istiocontrolplane_cr.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane
 metadata:
@@ -5,4 +6,4 @@ metadata:
   name: example-istiocontrolplane
 spec:
   profile: demo
----
+...

--- a/deploy/crds/istio_v1alpha2_istiocontrolplane_crd.yaml
+++ b/deploy/crds/istio_v1alpha2_istiocontrolplane_crd.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -47,4 +48,4 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
----
+...

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 namespace: istio-operator
 resources:
 - crds/istio_v1alpha2_istiocontrolplane_crd.yaml
@@ -7,4 +8,4 @@ resources:
 - service_account.yaml
 - operator.yaml
 - service.yaml
----
+...

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -1,5 +1,6 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: istio-operator
----
+...

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -41,4 +42,4 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "istio-operator"
----
+...

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,4 +13,4 @@ spec:
     targetPort: 8383
   selector:
     name: istio-operator
----
+...

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -1,6 +1,7 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: istio-operator
   name: istio-operator
----
+...


### PR DESCRIPTION
As per YAML specifications, YAML documents should begin with `---`
and conclude with `...`. Kubernetes accepts pretty sloppy yaml and
just requires a `---` although other tools, such as `yq` require
properly formatted YAML in order to operate correctly.