### PR TITLE
fix `make update-golden` when run from a Mac

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -83,7 +83,7 @@ docker.save: docker
 docker.all: docker docker.push
 
 update-goldens:
-	GOARCH=$(TARGET_ARCH) GOOS=$(TARGET_OS) REFRESH_GOLDEN=true go test ./cmd/mesh/...
+	REFRESH_GOLDEN=true go test ./cmd/mesh/...
 
 e2e:
 	@HUB=$(HUB) TAG=$(TAG) bash -c tests/e2e/e2e.sh


### PR DESCRIPTION
Setting the architecture results in a:
```
make update-goldens
Building with the build container: gcr.io/istio-testing/build-tools:2019-10-29T14-03-10.
Using docker credential directory /Users/ericvn/.docker.
GOARCH=amd64 GOOS=darwin REFRESH_GOLDEN=true go test ./cmd/mesh/...
fork/exec /tmp/go-build607960341/b001/mesh.test: exec format error
FAIL	istio.io/operator/cmd/mesh	0.005s
FAIL
Makefile.core.mk:86: recipe for target 'update-goldens' failed
make: *** [update-goldens] Error 1
make: *** [update-goldens] Error 2
```
as it's trying to run a Darwin executable in the Linux container.