### PR TITLE
Fix profile hub and tag for 1.4

### DIFF
--- a/data/profiles/default.yaml
+++ b/data/profiles/default.yaml
@@ -1,6 +1,10 @@
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane
 spec:
+  hub: gcr.io/istio-testing
+  tag: 1.4-dev
+  defaultNamespace: istio-system
+
   # Traffic management feature
   trafficManagement:
     enabled: true

--- a/data/profiles/default.yaml
+++ b/data/profiles/default.yaml
@@ -1,10 +1,6 @@
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane
 spec:
-  hub: gcr.io/istio-testing
-  tag: 1.4-dev
-  defaultNamespace: istio-system
-
   # Traffic management feature
   trafficManagement:
     enabled: true

--- a/data/profiles/demo-auth.yaml
+++ b/data/profiles/demo-auth.yaml
@@ -1,9 +1,6 @@
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane
 spec:
-  hub: gcr.io/istio-testing
-  tag: 1.4-dev
-  defaultNamespace: istio-system
   gateways:
     components:
       egressGateway:

--- a/data/profiles/demo.yaml
+++ b/data/profiles/demo.yaml
@@ -1,9 +1,6 @@
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane
 spec:
-  hub: gcr.io/istio-testing
-  tag: 1.4-dev
-  defaultNamespace: istio-system
   gateways:
     components:
       egressGateway:

--- a/data/profiles/minimal.yaml
+++ b/data/profiles/minimal.yaml
@@ -1,9 +1,6 @@
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane
 spec:
-  hub: gcr.io/istio-testing
-  tag: 1.4-dev
-  defaultNamespace: istio-system
   policy:
     enabled: false
 

--- a/data/profiles/sds.yaml
+++ b/data/profiles/sds.yaml
@@ -1,9 +1,6 @@
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane
 spec:
-  hub: gcr.io/istio-testing
-  tag: 1.4-dev
-  defaultNamespace: istio-system
   security:
     components:
       nodeAgent:


### PR DESCRIPTION
These were added only to the 1.4 branch for some reason in https://github.com/istio/operator/pull/448/files, so submitting directly to 1.4

https://github.com/istio/release-builder/pull/57 is the wrong fix

Fixes istio/istio#18668
Fixes istio/istio#18554