### PR TITLE
Drop log levels from info to debug

### DIFF
--- a/pkg/component/component/component.go
+++ b/pkg/component/component/component.go
@@ -787,7 +787,7 @@ func renderManifest(c *CommonComponentFields) (string, error) {
 		return "", err
 	}
 
-	log.Infof("Merged values:\n%s\n", mergedYAML)
+	log.Debugf("Merged values:\n%s\n", mergedYAML)
 
 	my, err := c.renderer.RenderManifest(mergedYAML)
 	if err != nil {
@@ -816,7 +816,7 @@ func renderManifest(c *CommonComponentFields) (string, error) {
 		return "", err
 	}
 	if !found {
-		log.Infof("Manifest after resources: \n%s\n", my)
+		log.Debugf("Manifest after resources: \n%s\n", my)
 		return my, nil
 	}
 	kyo, err := yaml.Marshal(overlays)

--- a/pkg/helm/vfs_renderer.go
+++ b/pkg/helm/vfs_renderer.go
@@ -64,7 +64,7 @@ type VFSRenderer struct {
 // NewVFSRenderer creates a VFSRenderer with the given relative path to helm charts, component name and namespace and
 // a base values YAML string.
 func NewVFSRenderer(helmChartDirPath, componentName, namespace string) *VFSRenderer {
-	log.Infof("NewVFSRenderer with helmChart=%s, componentName=%s, namespace=%s", helmChartDirPath, componentName, namespace)
+	log.Debugf("NewVFSRenderer with helmChart=%s, componentName=%s, namespace=%s", helmChartDirPath, componentName, namespace)
 	return &VFSRenderer{
 		namespace:        namespace,
 		componentName:    componentName,
@@ -74,7 +74,7 @@ func NewVFSRenderer(helmChartDirPath, componentName, namespace string) *VFSRende
 
 // Run implements the TemplateRenderer interface.
 func (h *VFSRenderer) Run() error {
-	log.Infof("Run VFSRenderer with helmChart=%s, componentName=%s, namespace=%s", h.helmChartDirPath, h.componentName, h.namespace)
+	log.Debugf("Run VFSRenderer with helmChart=%s, componentName=%s, namespace=%s", h.helmChartDirPath, h.componentName, h.namespace)
 	if err := h.loadChart(); err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func (h *VFSRenderer) loadChart() error {
 			Data: b,
 		}
 		bfs = append(bfs, bf)
-		log.Infof("Chart loaded: %s", bf.Name)
+		log.Debugf("Chart loaded: %s", bf.Name)
 	}
 
 	h.chart, err = chartutil.LoadFiles(bfs)

--- a/pkg/translate/translate.go
+++ b/pkg/translate/translate.go
@@ -136,9 +136,9 @@ func (t *Translator) OverlayK8sSettings(yml string, icp *v1alpha2.IstioControlPl
 	if err != nil {
 		return "", err
 	}
-	log.Infof("Manifest contains the following objects:")
+	log.Debugf("Manifest contains the following objects:")
 	for _, o := range objects {
-		log.Infof("%s", o.HashNameKind())
+		log.Debugf("%s", o.HashNameKind())
 	}
 	// om is a map of kind:name string to Object ptr.
 	om := objects.ToNameKindMap()
@@ -147,30 +147,30 @@ func (t *Translator) OverlayK8sSettings(yml string, icp *v1alpha2.IstioControlPl
 		if err != nil {
 			return "", err
 		}
-		log.Infof("Checking for path %s in IstioControlPlaneSpec", inPath)
+		log.Debugf("Checking for path %s in IstioControlPlaneSpec", inPath)
 		m, found, err := name.GetFromStructPath(icp, inPath)
 		if err != nil {
 			return "", err
 		}
 		if !found {
-			log.Infof("path %s not found in IstioControlPlaneSpec, skip mapping.", inPath)
+			log.Debugf("path %s not found in IstioControlPlaneSpec, skip mapping.", inPath)
 			continue
 		}
 		if mstr, ok := m.(string); ok && mstr == "" {
-			log.Infof("path %s is empty string, skip mapping.", inPath)
+			log.Debugf("path %s is empty string, skip mapping.", inPath)
 			continue
 		}
 		// Zero int values are due to proto3 compiling to scalars rather than ptrs. Skip these because values of 0 are
 		// the default in destination fields and need not be set explicitly.
 		if mint, ok := util.ToIntValue(m); ok && mint == 0 {
-			log.Infof("path %s is int 0, skip mapping.", inPath)
+			log.Debugf("path %s is int 0, skip mapping.", inPath)
 			continue
 		}
 		outPath, err := t.renderResourceComponentPathTemplate(v.OutPath, componentName)
 		if err != nil {
 			return "", err
 		}
-		log.Infof("path has value in IstioControlPlaneSpec, mapping to output path %s", outPath)
+		log.Debugf("path has value in IstioControlPlaneSpec, mapping to output path %s", outPath)
 		path := util.PathFromString(outPath)
 		pe := path[0]
 		// Output path must start with [kind:name], which is used to map to the object to overlay.


### PR DESCRIPTION
Without this change, there are 10,000 lines logged for `manifest
generate` which is way to noisy. These should be debug logging only, and
only useful user facing logs on info.