### PR TITLE
Remove unnecessary metadata validation part

### DIFF
--- a/deploy/crds/istio_v1alpha2_istiocontrolplane_crd.yaml
+++ b/deploy/crds/istio_v1alpha2_istiocontrolplane_crd.yaml
@@ -30,10 +30,6 @@ spec:
             submits requests to. Cannot be updated. In CamelCase.
             More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
-        metadata:
-          description: 'Metadata about the istio control plane resource.
-            More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata'
-          type: object
         spec:
           description: 'Specification of the desired state of the istio control plane resource.
             More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'


### PR DESCRIPTION
Try to resolve: https://github.com/istio/istio/issues/18803. 

See comments from this issue: https://github.com/kubernetes/kubernetes/issues/80493.  Metadata can only have name or generateName properties.