### PR TITLE
Update error message

### DIFF
--- a/cmd/mesh/manifest.go
+++ b/cmd/mesh/manifest.go
@@ -136,7 +136,7 @@ func genApplyManifests(setOverlay []string, inFilename string, force bool, dryRu
 	}
 	for cn := range manifests {
 		if out[cn].Err != nil {
-			cs := fmt.Sprintf("Component %s failed install:", cn)
+			cs := fmt.Sprintf("Component %s install returned the following errors:", cn)
 			l.logAndPrintf("\n%s\n%s", cs, strings.Repeat("=", len(cs)))
 			l.logAndPrint("Error: ", out[cn].Err, "\n")
 		} else {


### PR DESCRIPTION
There are cases where kubectl warnings appear as errors. In this case the component installs correctly, so in general it's better not to assert in the output that the component install failed. 
Eventually, we will want to integrate a post install health check into apply, in which case this type of message will be more appropriate.