### PR TITLE
update manifest migrate commands

### DIFF
--- a/cmd/mesh/testdata/manifest-migrate/output/values.yaml
+++ b/cmd/mesh/testdata/manifest-migrate/output/values.yaml
@@ -1,112 +1,463 @@
-autoInjection:
-  components:
-    injector:
-      enabled: true
-      k8s:
-        affinity:
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution: []
-            requiredDuringSchedulingIgnoredDuringExecution: []
-        nodeSelector: {}
-        replicaCount: 1
-        strategy:
-          rollingUpdate:
-            maxSurge: 100%
-            maxUnavailable: 25%
-        tolerations: []
-  enabled: true
-cni:
-  components:
-    cni:
-      enabled: false
-  enabled: false
-configManagement:
-  components:
+apiVersion: install.istio.io/v1alpha2
+kind: IstioControlPlane
+metadata:
+  creationTimestamp: null
+spec:
+  autoInjection:
+    components:
+      injector:
+        enabled: true
+        k8s:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution: []
+              requiredDuringSchedulingIgnoredDuringExecution: []
+          nodeSelector: {}
+          replicaCount: 1
+          strategy:
+            rollingUpdate:
+              maxSurge: 100%
+              maxUnavailable: 25%
+          tolerations: []
+    enabled: true
+  cni:
+    components:
+      cni:
+        enabled: false
+    enabled: false
+  configManagement:
+    components:
+      galley:
+        enabled: true
+        k8s:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution: []
+              requiredDuringSchedulingIgnoredDuringExecution: []
+          nodeSelector: {}
+          replicaCount: 1
+          resources:
+            requests:
+              cpu: 100m
+          strategy:
+            rollingUpdate:
+              maxSurge: 100%
+              maxUnavailable: 25%
+          tolerations: []
+    enabled: true
+  coreDNS:
+    components:
+      coreDNS:
+        enabled: false
+    enabled: false
+  gateways:
+    components:
+      egressGateway:
+        enabled: true
+        k8s:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution: []
+              requiredDuringSchedulingIgnoredDuringExecution: []
+          env:
+          - name: ISTIO_META_ROUTER_MODE
+            value: sni-dnat
+          hpaSpec:
+            maxReplicas: 5
+            metrics:
+            - resource:
+                name: cpu
+                targetAverageUtilization: 80
+              type: Resource
+            minReplicas: 1
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: istio-istio-egressgateway
+          nodeSelector: {}
+          podAnnotations: {}
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          strategy:
+            rollingUpdate:
+              maxSurge: 100%
+              maxUnavailable: 25%
+          tolerations: []
+      ingressGateway:
+        enabled: true
+        k8s:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution: []
+              requiredDuringSchedulingIgnoredDuringExecution: []
+          env:
+          - name: ISTIO_META_ROUTER_MODE
+            value: sni-dnat
+          hpaSpec:
+            maxReplicas: 5
+            metrics:
+            - resource:
+                name: cpu
+                targetAverageUtilization: 80
+              type: Resource
+            minReplicas: 1
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: istio-istio-ingressgateway
+          nodeSelector: {}
+          podAnnotations: {}
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          strategy:
+            rollingUpdate:
+              maxSurge: 100%
+              maxUnavailable: 25%
+          tolerations: []
+    enabled: true
+  hub: gcr.io/istio-release
+  policy:
+    components:
+      policy:
+        enabled: true
+        k8s:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution: []
+              requiredDuringSchedulingIgnoredDuringExecution: []
+          env:
+          - name: GODEBUG
+            value: gctrace=1
+          hpaSpec:
+            maxReplicas: 5
+            metrics:
+            - resource:
+                name: cpu
+                targetAverageUtilization: 80
+              type: Resource
+            minReplicas: 1
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: istio-policy
+          nodeSelector: {}
+          podAnnotations: {}
+          replicaCount: 1
+          strategy:
+            rollingUpdate:
+              maxSurge: 100%
+              maxUnavailable: 25%
+          tolerations: []
+    enabled: true
+  security:
+    components:
+      certManager:
+        enabled: false
+      citadel:
+        enabled: true
+        k8s:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution: []
+              requiredDuringSchedulingIgnoredDuringExecution: []
+          nodeSelector: {}
+          replicaCount: 1
+          strategy:
+            rollingUpdate:
+              maxSurge: 100%
+              maxUnavailable: 25%
+          tolerations: []
+      nodeAgent:
+        enabled: false
+    enabled: true
+  tag: master-latest-daily
+  telemetry:
+    components:
+      telemetry:
+        enabled: true
+        k8s:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution: []
+              requiredDuringSchedulingIgnoredDuringExecution: []
+          hpaSpec:
+            maxReplicas: 5
+            metrics:
+            - resource:
+                name: cpu
+                targetAverageUtilization: 80
+              type: Resource
+            minReplicas: 1
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: istio-telemetry
+          nodeSelector: {}
+          replicaCount: 1
+          resources:
+            limits:
+              cpu: 4800m
+              memory: 4G
+            requests:
+              cpu: 1000m
+              memory: 1G
+          strategy:
+            rollingUpdate:
+              maxSurge: 100%
+              maxUnavailable: 25%
+          tolerations: []
+    enabled: true
+  trafficManagement:
+    components:
+      pilot:
+        enabled: true
+        k8s:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution: []
+              requiredDuringSchedulingIgnoredDuringExecution: []
+          env:
+          - name: GODEBUG
+            value: gctrace=1
+          hpaSpec:
+            maxReplicas: 5
+            metrics:
+            - resource:
+                name: cpu
+                targetAverageUtilization: 80
+              type: Resource
+            minReplicas: 1
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: istio-pilot
+          nodeSelector: {}
+          replicaCount: 1
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2048Mi
+          strategy:
+            rollingUpdate:
+              maxSurge: 100%
+              maxUnavailable: 25%
+          tolerations: []
+    enabled: true
+  values:
+    certmanager:
+      hub: quay.io/jetstack
+      image: cert-manager-controller
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      replicaCount: 1
+      tag: v0.6.2
+      tolerations: []
     galley:
-      enabled: true
-      k8s:
-        affinity:
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution: []
-            requiredDuringSchedulingIgnoredDuringExecution: []
-        nodeSelector: {}
-        replicaCount: 1
-        resources:
-          requests:
-            cpu: 100m
-        strategy:
-          rollingUpdate:
-            maxSurge: 100%
-            maxUnavailable: 25%
-        tolerations: []
-  enabled: true
-coreDNS:
-  components:
-    coreDNS:
-      enabled: false
-  enabled: false
-gateways:
-  components:
-    egressGateway:
-      enabled: true
-      k8s:
-        affinity:
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution: []
-            requiredDuringSchedulingIgnoredDuringExecution: []
-        env:
-        - name: ISTIO_META_ROUTER_MODE
-          value: sni-dnat
-        hpaSpec:
-          maxReplicas: 5
-          metrics:
-          - resource:
-              name: cpu
-              targetAverageUtilization: 80
-            type: Resource
-          minReplicas: 1
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: istio-gateways.istio-egressgateway
-        nodeSelector: {}
-        podAnnotations: {}
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 256Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        strategy:
-          rollingUpdate:
-            maxSurge: 100%
-            maxUnavailable: 25%
-        tolerations: []
-    ingressGateway:
-      enabled: true
-      k8s:
-        affinity:
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution: []
-            requiredDuringSchedulingIgnoredDuringExecution: []
-        env:
-        - name: ISTIO_META_ROUTER_MODE
-          value: sni-dnat
-        hpaSpec:
-          maxReplicas: 5
-          metrics:
-          - resource:
-              name: cpu
-              targetAverageUtilization: 80
-            type: Resource
-          minReplicas: 1
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: istio-gateways.istio-ingressgateway
-        nodeSelector: {}
-        podAnnotations: {}
+      image: galley
+    gateways:
+      istio-egressgateway:
+        connectTimeout: 10s
+        drainDuration: 45s
+        ports:
+        - name: http2
+          port: 80
+        - name: https
+          port: 443
+        - name: tls
+          port: 15443
+          targetPort: 15443
+        secretVolumes:
+        - mountPath: /etc/istio/egressgateway-certs
+          name: egressgateway-certs
+          secretName: istio-egressgateway-certs
+        - mountPath: /etc/istio/egressgateway-ca-certs
+          name: egressgateway-ca-certs
+          secretName: istio-egressgateway-ca-certs
+        type: ClusterIP
+        zvpn:
+          enabled: true
+          suffix: global
+      istio-ingressgateway:
+        applicationPorts: ""
+        debug: info
+        domain: ""
+        externalIPs: []
+        loadBalancerIP: ""
+        loadBalancerSourceRanges: []
+        meshExpansionPorts:
+        - name: tcp-pilot-grpc-tls
+          port: 15011
+          targetPort: 15011
+        - name: tcp-citadel-grpc-tls
+          port: 8060
+          targetPort: 8060
+        - name: tcp-dns-tls
+          port: 853
+          targetPort: 853
+        ports:
+        - name: status-port
+          port: 15020
+          targetPort: 15020
+        - name: http2
+          port: 80
+          targetPort: 80
+        - name: https
+          port: 443
+        - name: kiali
+          port: 15029
+          targetPort: 15029
+        - name: prometheus
+          port: 15030
+          targetPort: 15030
+        - name: grafana
+          port: 15031
+          targetPort: 15031
+        - name: tracing
+          port: 15032
+          targetPort: 15032
+        - name: tls
+          port: 15443
+          targetPort: 15443
+        sds:
+          enabled: false
+          image: node-agent-k8s
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+        secretVolumes:
+        - mountPath: /etc/istio/ingressgateway-certs
+          name: ingressgateway-certs
+          secretName: istio-ingressgateway-certs
+        - mountPath: /etc/istio/ingressgateway-ca-certs
+          name: ingressgateway-ca-certs
+          secretName: istio-ingressgateway-ca-certs
+        telemetry_addon_gateways:
+          grafana_gateway:
+            desPort: 3000
+            enabled: false
+            name: grafana
+            port: 15031
+            tls: false
+          kiali_gateway:
+            desPort: 20001
+            enabled: false
+            name: kiali
+            port: 15029
+            tls: false
+          prometheus_gateway:
+            desPort: 9090
+            enabled: false
+            name: prometheus
+            port: 15030
+            tls: false
+          tracing_gateway:
+            desPort: 80
+            enabled: false
+            name: tracing
+            port: 15032
+            tls: false
+        telemetry_domain_name: ""
+        type: LoadBalancer
+        zvpn:
+          enabled: true
+          suffix: global
+    global:
+      arch:
+        amd64: 2
+        ppc64le: 2
+        s390x: 2
+      configValidation: true
+      controlPlaneSecurityEnabled: false
+      defaultPodDisruptionBudget:
+        enabled: true
+      defaultResources:
+        requests:
+          cpu: 10m
+      defaultTolerations: []
+      disablePolicyChecks: true
+      enableHelmTest: false
+      enableTracing: true
+      imagePullPolicy: IfNotPresent
+      imagePullSecrets: []
+      k8sIngress:
+        enableHttps: false
+        enabled: false
+        gatewayName: ingressgateway
+      localityLbSetting:
+        enabled: true
+      logging:
+        level: default:info
+      meshExpansion:
+        enabled: false
+        useILB: false
+      meshID: ""
+      monitoringPort: 15014
+      mtls:
+        enabled: false
+      multiCluster:
+        enabled: false
+      oneNamespace: false
+      policyCheckFailOpen: false
+      priorityClassName: ""
+      proxy:
+        accessLogEncoding: TEXT
+        accessLogFile: ""
+        accessLogFormat: ""
+        autoInject: enabled
+        clusterDomain: cluster.local
+        componentLogLevel: ""
+        concurrency: 2
+        dnsRefreshRate: 300s
+        enableCoreDump: false
+        enableCoreDumpImage: ubuntu:xenial
+        envoyAccessLogService:
+          enabled: false
+          tcpKeepalive:
+            interval: 10s
+            probes: 3
+            time: 10s
+          tlsSettings:
+            mode: DISABLE
+            subjectAltNames: []
+        envoyMetricsService:
+          enabled: false
+        envoyStatsd:
+          enabled: false
+        excludeIPRanges: ""
+        excludeInboundPorts: ""
+        excludeOutboundPorts: ""
+        image: proxyv2
+        includeIPRanges: '*'
+        includeInboundPorts: '*'
+        init:
+          resources:
+            limits:
+              cpu: 100m
+              memory: 50Mi
+            requests:
+              cpu: 10m
+              memory: 10Mi
+        kubevirtInterfaces: ""
+        logLevel: ""
+        privileged: false
+        protocolDetectionTimeout: 10ms
+        readinessFailureThreshold: 30
+        readinessInitialDelaySeconds: 1
+        readinessPeriodSeconds: 2
         resources:
           limits:
             cpu: 2000m
@@ -114,594 +465,248 @@ gateways:
           requests:
             cpu: 100m
             memory: 128Mi
-        strategy:
-          rollingUpdate:
-            maxSurge: 100%
-            maxUnavailable: 25%
-        tolerations: []
-  enabled: true
-hub: gcr.io/istio-release
-policy:
-  components:
-    policy:
-      enabled: true
-      k8s:
-        affinity:
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution: []
-            requiredDuringSchedulingIgnoredDuringExecution: []
-        env:
-        - name: GODEBUG
-          value: gctrace=1
-        hpaSpec:
-          maxReplicas: 5
-          metrics:
-          - resource:
-              name: cpu
-              targetAverageUtilization: 80
-            type: Resource
-          minReplicas: 1
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: istio-mixer.policy
-        nodeSelector: {}
-        podAnnotations: {}
-        replicaCount: 1
-        strategy:
-          rollingUpdate:
-            maxSurge: 100%
-            maxUnavailable: 25%
-        tolerations: []
-  enabled: true
-security:
-  components:
-    certManager:
-      enabled: false
-    citadel:
-      enabled: true
-      k8s:
-        affinity:
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution: []
-            requiredDuringSchedulingIgnoredDuringExecution: []
-        nodeSelector: {}
-        replicaCount: 1
-        strategy:
-          rollingUpdate:
-            maxSurge: 100%
-            maxUnavailable: 25%
-        tolerations: []
-    nodeAgent:
-      enabled: false
-  enabled: true
-tag: master-latest-daily
-telemetry:
-  components:
-    telemetry:
-      enabled: true
-      k8s:
-        affinity:
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution: []
-            requiredDuringSchedulingIgnoredDuringExecution: []
-        hpaSpec:
-          maxReplicas: 5
-          metrics:
-          - resource:
-              name: cpu
-              targetAverageUtilization: 80
-            type: Resource
-          minReplicas: 1
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: istio-mixer.telemetry
-        nodeSelector: {}
-        replicaCount: 1
-        resources:
-          limits:
-            cpu: 4800m
-            memory: 4G
-          requests:
-            cpu: 1000m
-            memory: 1G
-        strategy:
-          rollingUpdate:
-            maxSurge: 100%
-            maxUnavailable: 25%
-        tolerations: []
-  enabled: true
-trafficManagement:
-  components:
-    pilot:
-      enabled: true
-      k8s:
-        affinity:
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution: []
-            requiredDuringSchedulingIgnoredDuringExecution: []
-        env:
-        - name: GODEBUG
-          value: gctrace=1
-        hpaSpec:
-          maxReplicas: 5
-          metrics:
-          - resource:
-              name: cpu
-              targetAverageUtilization: 80
-            type: Resource
-          minReplicas: 1
-          scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: istio-pilot
-        nodeSelector: {}
-        replicaCount: 1
-        resources:
-          requests:
-            cpu: 500m
-            memory: 2048Mi
-        strategy:
-          rollingUpdate:
-            maxSurge: 100%
-            maxUnavailable: 25%
-        tolerations: []
-  enabled: true
-values:
-  certmanager:
-    hub: quay.io/jetstack
-    image: cert-manager-controller
-    podAntiAffinityLabelSelector: []
-    podAntiAffinityTermLabelSelector: []
-    replicaCount: 1
-    tag: v0.6.2
-    tolerations: []
-  galley:
-    image: galley
-  gateways:
-    istio-egressgateway:
-      connectTimeout: 10s
-      drainDuration: 45s
-      ports:
-      - name: http2
-        port: 80
-      - name: https
-        port: 443
-      - name: tls
-        port: 15443
-        targetPort: 15443
-      secretVolumes:
-      - mountPath: /etc/istio/egressgateway-certs
-        name: egressgateway-certs
-        secretName: istio-egressgateway-certs
-      - mountPath: /etc/istio/egressgateway-ca-certs
-        name: egressgateway-ca-certs
-        secretName: istio-egressgateway-ca-certs
-      type: ClusterIP
-      zvpn:
-        enabled: true
-        suffix: global
-    istio-ingressgateway:
-      applicationPorts: ""
-      debug: info
-      domain: ""
-      externalIPs: []
-      loadBalancerIP: ""
-      loadBalancerSourceRanges: []
-      meshExpansionPorts:
-      - name: tcp-pilot-grpc-tls
-        port: 15011
-        targetPort: 15011
-      - name: tcp-citadel-grpc-tls
-        port: 8060
-        targetPort: 8060
-      - name: tcp-dns-tls
-        port: 853
-        targetPort: 853
-      ports:
-      - name: status-port
-        port: 15020
-        targetPort: 15020
-      - name: http2
-        port: 80
-        targetPort: 80
-      - name: https
-        port: 443
-      - name: kiali
-        port: 15029
-        targetPort: 15029
-      - name: prometheus
-        port: 15030
-        targetPort: 15030
-      - name: grafana
-        port: 15031
-        targetPort: 15031
-      - name: tracing
-        port: 15032
-        targetPort: 15032
-      - name: tls
-        port: 15443
-        targetPort: 15443
+        statusPort: 15020
+        tracer: zipkin
+      proxy_init:
+        image: proxy_init
       sds:
         enabled: false
-        image: node-agent-k8s
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 1024Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-      secretVolumes:
-      - mountPath: /etc/istio/ingressgateway-certs
-        name: ingressgateway-certs
-        secretName: istio-ingressgateway-certs
-      - mountPath: /etc/istio/ingressgateway-ca-certs
-        name: ingressgateway-ca-certs
-        secretName: istio-ingressgateway-ca-certs
-      telemetry_addon_gateways:
-        grafana_gateway:
-          desPort: 3000
-          enabled: false
-          name: grafana
-          port: 15031
-          tls: false
-        kiali_gateway:
-          desPort: 20001
-          enabled: false
-          name: kiali
-          port: 15029
-          tls: false
-        prometheus_gateway:
-          desPort: 9090
-          enabled: false
-          name: prometheus
-          port: 15030
-          tls: false
-        tracing_gateway:
-          desPort: 80
-          enabled: false
-          name: tracing
-          port: 15032
-          tls: false
-      telemetry_domain_name: ""
-      type: LoadBalancer
-      zvpn:
-        enabled: true
-        suffix: global
-  global:
-    arch:
-      amd64: 2
-      ppc64le: 2
-      s390x: 2
-    configValidation: true
-    controlPlaneSecurityEnabled: false
-    defaultPodDisruptionBudget:
-      enabled: true
-    defaultResources:
-      requests:
-        cpu: 10m
-    defaultTolerations: []
-    disablePolicyChecks: true
-    enableHelmTest: false
-    enableTracing: true
-    imagePullPolicy: IfNotPresent
-    imagePullSecrets: []
-    k8sIngress:
-      enableHttps: false
-      enabled: false
-      gatewayName: ingressgateway
-    localityLbSetting:
-      enabled: true
-    logging:
-      level: default:info
-    meshExpansion:
-      enabled: false
-      useILB: false
-    meshID: ""
-    monitoringPort: 15014
-    mtls:
-      enabled: false
-    multiCluster:
-      enabled: false
-    oneNamespace: false
-    policyCheckFailOpen: false
-    priorityClassName: ""
-    proxy:
-      accessLogEncoding: TEXT
-      accessLogFile: ""
-      accessLogFormat: ""
-      autoInject: enabled
-      clusterDomain: cluster.local
-      componentLogLevel: ""
-      concurrency: 2
-      dnsRefreshRate: 300s
-      enableCoreDump: false
-      enableCoreDumpImage: ubuntu:xenial
-      envoyAccessLogService:
-        enabled: false
-        tcpKeepalive:
-          interval: 10s
-          probes: 3
-          time: 10s
-        tlsSettings:
-          mode: DISABLE
-          subjectAltNames: []
-      envoyMetricsService:
-        enabled: false
-      envoyStatsd:
-        enabled: false
-      excludeIPRanges: ""
-      excludeInboundPorts: ""
-      excludeOutboundPorts: ""
-      image: proxyv2
-      includeIPRanges: '*'
-      includeInboundPorts: '*'
-      init:
-        resources:
-          limits:
-            cpu: 100m
-            memory: 50Mi
-          requests:
-            cpu: 10m
-            memory: 10Mi
-      kubevirtInterfaces: ""
-      logLevel: ""
-      privileged: false
-      protocolDetectionTimeout: 10ms
-      readinessFailureThreshold: 30
-      readinessInitialDelaySeconds: 1
-      readinessPeriodSeconds: 2
-      resources:
-        limits:
-          cpu: 2000m
-          memory: 1024Mi
-        requests:
-          cpu: 100m
-          memory: 128Mi
-      statusPort: 15020
-      tracer: zipkin
-    proxy_init:
-      image: proxy_init
-    sds:
-      enabled: false
-      udsPath: ""
-    tracer:
-      datadog:
-        address: $(HOST_IP):8126
-      lightstep:
-        accessToken: ""
-        address: ""
-        cacertPath: ""
-        secure: true
-      zipkin:
-        address: ""
-    trustDomain: ""
-    useMCP: true
-  grafana:
-    accessMode: ReadWriteMany
-    contextPath: /grafana
-    dashboardProviders:
-      dashboardproviders:
-        yaml:
-          apiVersion: 1
-          providers:
-          - disableDeletion: false
-            folder: istio
-            name: istio
-            options:
-              path: /var/lib/grafana/dashboards/istio
-            orgId: 1
-            type: file
-    datasources:
-      datasources:
-        yaml:
-          apiVersion: 1
-          datasources:
-          - access: proxy
-            editable: true
-            isDefault: true
-            jsonData:
-              timeInterval: 5s
-            name: Prometheus
-            orgId: 1
-            type: prometheus
-            url: http://prometheus:9090
-    enabled: false
-    image:
-      repository: grafana/grafana
-      tag: 6.1.6
-    ingress:
-      enabled: false
-      hosts:
-      - grafana.local
-    persist: false
-    podAntiAffinityLabelSelector: []
-    podAntiAffinityTermLabelSelector: []
-    replicaCount: 1
-    security:
-      enabled: false
-      passphraseKey: passphrase
-      secretName: grafana
-      usernameKey: username
-    service:
-      externalPort: 3000
-      name: http
-      type: ClusterIP
-    storageClassName: ""
-    tolerations: []
-  istio_cni:
-    cniBinDir: /opt/cni/bin
-    cniConfDir: /etc/cni/net.d
-    enabled: false
-    excludeNamespaces:
-    - istio-system
-    hub: gcr.io/istio-release
-    logLevel: info
-    pullPolicy: Always
-    tag: master-latest-daily
-  istiocoredns:
-    coreDNSImage: coredns/coredns:1.1.2
-    coreDNSPluginImage: istio/coredns-plugin:0.2-istio-1.1
-    podAntiAffinityLabelSelector: []
-    podAntiAffinityTermLabelSelector: []
-    replicaCount: 1
-    tolerations: []
-  kiali:
-    contextPath: /kiali
-    createDemoSecret: false
-    dashboard:
-      auth:
-        strategy: login
-      secretName: kiali
-      viewOnlyMode: false
-    enabled: false
-    hub: quay.io/kiali
-    image: kiali
-    ingress:
-      enabled: false
-      hosts:
-      - kiali.local
-    podAntiAffinityLabelSelector: []
-    podAntiAffinityTermLabelSelector: []
-    prometheusAddr: http://prometheus:9090
-    replicaCount: 1
-    security:
-      cert_file: /kiali-cert/cert-chain.pem
-      enabled: true
-      private_key_file: /kiali-cert/key.pem
-    tag: v1.1.0
-    tolerations: []
-  mixer:
-    policy:
-      adapters:
-        kubernetesenv:
-          enabled: true
-      image: mixer
-    telemetry:
-      image: mixer
-      loadshedding:
-        latencyThreshold: 100ms
-        mode: enforce
-      reportBatchMaxEntries: 100
-      reportBatchMaxTime: 1s
-      sessionAffinityEnabled: false
+        udsPath: ""
+      tracer:
+        datadog:
+          address: $(HOST_IP):8126
+        lightstep:
+          accessToken: ""
+          address: ""
+          cacertPath: ""
+          secure: true
+        zipkin:
+          address: ""
+      trustDomain: ""
       useMCP: true
-  nodeagent:
-    env:
-      cA_ADDR: ""
-      cA_PROVIDER: ""
-      plugins: ""
-    image: node-agent-k8s
-    podAntiAffinityLabelSelector: []
-    podAntiAffinityTermLabelSelector: []
-    tolerations: []
-  pilot:
-    appNamespaces: []
-    configMap: true
-    configNamespace: istio-config
-    image: pilot
-    ingress:
-      ingressClass: istio
-      ingressControllerMode: "OFF"
-      ingressService: istio-ingressgateway
-    keepaliveMaxServerConnectionAge: 30m
-    policy:
-      enabled: false
-    telemetry:
-      enabled: true
-    traceSampling: 1
-    useMCP: true
-  prometheus:
-    contextPath: /prometheus
-    enabled: true
-    hub: docker.io/prom
-    image: prometheus
-    ingress:
-      enabled: false
-      hosts:
-      - prometheus.local
-    podAntiAffinityLabelSelector: []
-    podAntiAffinityTermLabelSelector: []
-    replicaCount: 1
-    retention: 6h
-    scrapeInterval: 15s
-    security:
-      enabled: true
-    service:
-      nodePort:
-        enabled: false
-        port: 32090
-    tag: v2.8.0
-    tolerations: []
-  security:
-    dnsCerts:
-      istio-galley-service-account:
-        istio-config: istio-galley.istio-config.svc
-        istio-control: istio-galley.istio-control.svc
-        istio-control-master: istio-galley.istio-control-master.svc
-        istio-master: istio-galley.istio-master.svc
-        istio-pilot11: istio-galley.istio-pilot11.svc
-      istio-pilot-service-account:
-        istio-control: istio-pilot-service-account.istio-control
-        istio-pilot11: istio-pilot-service-account.istio-system
-      istio-sidecar-injector-service-account:
-        istio-control: istio-sidecar-injector.istio-control.svc
-        istio-control-master: istio-sidecar-injector.istio-control-master.svc
-        istio-master: istio-sidecar-injector.istio-master.svc
-        istio-pilot11: istio-sidecar-injector.istio-pilot11.svc
-        istio-remote: istio-sidecar-injector.istio-remote.svc
-    enableNamespacesByDefault: true
-    image: citadel
-    selfSigned: true
-    trustDomain: cluster.local
-    workloadCertTtl: 2160h
-  sidecarInjectorWebhook:
-    alwaysInjectSelector: []
-    enableNamespacesByDefault: false
-    image: sidecar_injector
-    injectLabel: istio-injection
-    neverInjectSelector: []
-    rewriteAppHTTPProbe: false
-    selfSigned: false
-  tracing:
-    enabled: false
-    ingress:
-      enabled: false
-    jaeger:
+    grafana:
       accessMode: ReadWriteMany
-      hub: docker.io/jaegertracing
-      image: all-in-one
-      memory:
-        max_traces: 50000
+      contextPath: /grafana
+      dashboardProviders:
+        dashboardproviders:
+          yaml:
+            apiVersion: 1
+            providers:
+            - disableDeletion: false
+              folder: istio
+              name: istio
+              options:
+                path: /var/lib/grafana/dashboards/istio
+              orgId: 1
+              type: file
+      datasources:
+        datasources:
+          yaml:
+            apiVersion: 1
+            datasources:
+            - access: proxy
+              editable: true
+              isDefault: true
+              jsonData:
+                timeInterval: 5s
+              name: Prometheus
+              orgId: 1
+              type: prometheus
+              url: http://prometheus:9090
+      enabled: false
+      image:
+        repository: grafana/grafana
+        tag: 6.1.6
+      ingress:
+        enabled: false
+        hosts:
+        - grafana.local
       persist: false
-      spanStorageType: badger
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      replicaCount: 1
+      security:
+        enabled: false
+        passphraseKey: passphrase
+        secretName: grafana
+        usernameKey: username
+      service:
+        externalPort: 3000
+        name: http
+        type: ClusterIP
       storageClassName: ""
-      tag: 1.12
-    podAntiAffinityLabelSelector: []
-    podAntiAffinityTermLabelSelector: []
-    provider: jaeger
-    service:
-      externalPort: 9411
-      name: http
-      type: ClusterIP
-    tolerations: []
-    zipkin:
-      hub: docker.io/openzipkin
-      image: zipkin
-      javaOptsHeap: 700
-      maxSpans: 500000
-      node:
-        cpus: 2
-      probeStartupDelay: 200
-      queryPort: 9411
-      resources:
-        limits:
-          cpu: 300m
-          memory: 900Mi
-        requests:
-          cpu: 150m
-          memory: 900Mi
-      tag: 2.14.2
+      tolerations: []
+    istio_cni:
+      cniBinDir: /opt/cni/bin
+      cniConfDir: /etc/cni/net.d
+      enabled: false
+      excludeNamespaces:
+      - istio-system
+      hub: gcr.io/istio-release
+      logLevel: info
+      pullPolicy: Always
+      tag: master-latest-daily
+    istiocoredns:
+      coreDNSImage: coredns/coredns:1.1.2
+      coreDNSPluginImage: istio/coredns-plugin:0.2-istio-1.1
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      replicaCount: 1
+      tolerations: []
+    kiali:
+      contextPath: /kiali
+      createDemoSecret: false
+      dashboard:
+        auth:
+          strategy: login
+        secretName: kiali
+        viewOnlyMode: false
+      enabled: false
+      hub: quay.io/kiali
+      image: kiali
+      ingress:
+        enabled: false
+        hosts:
+        - kiali.local
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      prometheusAddr: http://prometheus:9090
+      replicaCount: 1
+      security:
+        cert_file: /kiali-cert/cert-chain.pem
+        enabled: true
+        private_key_file: /kiali-cert/key.pem
+      tag: v1.1.0
+      tolerations: []
+    mixer:
+      policy:
+        adapters:
+          kubernetesenv:
+            enabled: true
+        image: mixer
+      telemetry:
+        image: mixer
+        loadshedding:
+          latencyThreshold: 100ms
+          mode: enforce
+        reportBatchMaxEntries: 100
+        reportBatchMaxTime: 1s
+        sessionAffinityEnabled: false
+        useMCP: true
+    nodeagent:
+      env:
+        cA_ADDR: ""
+        cA_PROVIDER: ""
+        plugins: ""
+      image: node-agent-k8s
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      tolerations: []
+    pilot:
+      appNamespaces: []
+      configMap: true
+      configNamespace: istio-config
+      image: pilot
+      ingress:
+        ingressClass: istio
+        ingressControllerMode: "OFF"
+        ingressService: istio-ingressgateway
+      keepaliveMaxServerConnectionAge: 30m
+      policy:
+        enabled: false
+      telemetry:
+        enabled: true
+      traceSampling: 1
+      useMCP: true
+    prometheus:
+      contextPath: /prometheus
+      enabled: true
+      hub: docker.io/prom
+      image: prometheus
+      ingress:
+        enabled: false
+        hosts:
+        - prometheus.local
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      replicaCount: 1
+      retention: 6h
+      scrapeInterval: 15s
+      security:
+        enabled: true
+      service:
+        nodePort:
+          enabled: false
+          port: 32090
+      tag: v2.8.0
+      tolerations: []
+    security:
+      dnsCerts:
+        istio-galley-service-account:
+          istio-config: istio-galley.istio-config.svc
+          istio-control: istio-galley.istio-control.svc
+          istio-control-master: istio-galley.istio-control-master.svc
+          istio-master: istio-galley.istio-master.svc
+          istio-pilot11: istio-galley.istio-pilot11.svc
+        istio-pilot-service-account:
+          istio-control: istio-pilot-service-account.istio-control
+          istio-pilot11: istio-pilot-service-account.istio-system
+        istio-sidecar-injector-service-account:
+          istio-control: istio-sidecar-injector.istio-control.svc
+          istio-control-master: istio-sidecar-injector.istio-control-master.svc
+          istio-master: istio-sidecar-injector.istio-master.svc
+          istio-pilot11: istio-sidecar-injector.istio-pilot11.svc
+          istio-remote: istio-sidecar-injector.istio-remote.svc
+      enableNamespacesByDefault: true
+      image: citadel
+      selfSigned: true
+      trustDomain: cluster.local
+      workloadCertTtl: 2160h
+    sidecarInjectorWebhook:
+      alwaysInjectSelector: []
+      enableNamespacesByDefault: false
+      image: sidecar_injector
+      injectLabel: istio-injection
+      neverInjectSelector: []
+      rewriteAppHTTPProbe: false
+      selfSigned: false
+    tracing:
+      enabled: false
+      ingress:
+        enabled: false
+      jaeger:
+        accessMode: ReadWriteMany
+        hub: docker.io/jaegertracing
+        image: all-in-one
+        memory:
+          max_traces: 50000
+        persist: false
+        spanStorageType: badger
+        storageClassName: ""
+        tag: 1.12
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
+      provider: jaeger
+      service:
+        externalPort: 9411
+        name: http
+        type: ClusterIP
+      tolerations: []
+      zipkin:
+        hub: docker.io/openzipkin
+        image: zipkin
+        javaOptsHeap: 700
+        maxSpans: 500000
+        node:
+          cpus: 2
+        probeStartupDelay: 200
+        queryPort: 9411
+        resources:
+          limits:
+            cpu: 300m
+            memory: 900Mi
+          requests:
+            cpu: 150m
+            memory: 900Mi
+        tag: 2.14.2
 

--- a/pkg/translate/translate_value.go
+++ b/pkg/translate/translate_value.go
@@ -81,13 +81,13 @@ var (
 	// Feature enablement mapping. Ex: "{{.ValueComponent}}.enabled": {"{{.FeatureName}}.enabled}", nil},
 	componentEnablementPattern = "{{.FeatureName}}.Components.{{.ComponentName}}.Enabled"
 	// specialComponentPath lists cases of component path of values.yaml we need to have special treatment.
-	specialComponentPath = map[string]string{
-		"mixer":                         "",
-		"mixer.policy":                  "",
-		"mixer.telemetry":               "",
-		"gateways":                      "",
-		"gateways.istio-ingressgateway": "",
-		"gateways.istio-egressgateway":  "",
+	specialComponentPath = map[string]bool{
+		"mixer":                         true,
+		"mixer.policy":                  true,
+		"mixer.telemetry":               true,
+		"gateways":                      true,
+		"gateways.istio-ingressgateway": true,
+		"gateways.istio-egressgateway":  true,
 	}
 )
 
@@ -336,7 +336,7 @@ name: istio-%s`
 
 	// need to do special handling for gateways and mixer
 	// ex. because deployment name should be istio-telemetry instead of istio-mixer.telemetry, we need to get rid of the prefix mixer part.
-	if _, exist := specialComponentPath[newPS]; exist && len(newP) > 2 {
+	if specialComponentPath[newPS] && len(newP) > 2 {
 		newPS = newP[1 : len(newP)-1].String()
 	}
 
@@ -549,7 +549,7 @@ func (t *ReverseTranslator) isEnablementPath(path util.Path) bool {
 	}
 
 	pf := path[:len(path)-1].String()
-	if _, exist := specialComponentPath[pf]; exist {
+	if specialComponentPath[pf] {
 		return true
 	}
 

--- a/pkg/translate/translate_value.go
+++ b/pkg/translate/translate_value.go
@@ -325,6 +325,13 @@ apiVersion: apps/v1
 kind: Deployment
 name: istio-%s`
 
+	// need to do special handling for gateways and mixer
+	// ex. deployment name should be istio-telemetry instead of istio-mixer.telemetry
+	if newPS == "mixer.policy" || newPS == "mixer.telemetry" ||
+		newPS == "gateways.istio-ingressgateway" || newPS == "gateways.istio-egressgateway" {
+		newPS = newP[1 : len(newP)-1].String()
+	}
+
 	stString := fmt.Sprintf(stVal, newPS)
 	if err := yaml.Unmarshal([]byte(stString), &st); err != nil {
 		return err
@@ -535,7 +542,7 @@ func (t *ReverseTranslator) isEnablementPath(path util.Path) bool {
 
 	pstr := path.String()
 	if pstr == "mixer.policy.enabled" || pstr == "mixer.telemetry.enabled" ||
-		pstr == "gateways.enabled" ||
+		pstr == "gateways.enabled" || pstr == "mixer.enabled" ||
 		pstr == "gateways.istio-ingressgateway.enabled" || pstr == "gateways.istio-egressgateway.enabled" {
 		return true
 	}

--- a/pkg/translate/translate_value.go
+++ b/pkg/translate/translate_value.go
@@ -81,8 +81,14 @@ var (
 	// Feature enablement mapping. Ex: "{{.ValueComponent}}.enabled": {"{{.FeatureName}}.enabled}", nil},
 	componentEnablementPattern = "{{.FeatureName}}.Components.{{.ComponentName}}.Enabled"
 	// specialComponentPath lists cases of component path of values.yaml we need to have special treatment.
-	specialComponentPath = []string{"mixer.policy", "mixer.telemetry", "gateways.istio-ingressgateway", "gateways.istio-egressgateway",
-		"mixer", "gateways"}
+	specialComponentPath = map[string]string{
+		"mixer":                         "",
+		"mixer.policy":                  "",
+		"mixer.telemetry":               "",
+		"gateways":                      "",
+		"gateways.istio-ingressgateway": "",
+		"gateways.istio-egressgateway":  "",
+	}
 )
 
 // initAPIMapping generate the reverse mapping from original translator apiMapping.
@@ -330,10 +336,8 @@ name: istio-%s`
 
 	// need to do special handling for gateways and mixer
 	// ex. because deployment name should be istio-telemetry instead of istio-mixer.telemetry, we need to get rid of the prefix mixer part.
-	for _, cp := range specialComponentPath {
-		if cp == newPS && len(newP) > 2 {
-			newPS = newP[1 : len(newP)-1].String()
-		}
+	if _, exist := specialComponentPath[newPS]; exist && len(newP) > 2 {
+		newPS = newP[1 : len(newP)-1].String()
 	}
 
 	stString := fmt.Sprintf(stVal, newPS)
@@ -545,10 +549,8 @@ func (t *ReverseTranslator) isEnablementPath(path util.Path) bool {
 	}
 
 	pf := path[:len(path)-1].String()
-	for _, cp := range specialComponentPath {
-		if cp == pf {
-			return true
-		}
+	if _, exist := specialComponentPath[pf]; exist {
+		return true
 	}
 
 	_, exist := t.ValuesToComponentName[pf]

--- a/pkg/translate/translate_value_test.go
+++ b/pkg/translate/translate_value_test.go
@@ -396,7 +396,7 @@ autoInjection:
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			valueStruct := v1alpha1.Values{}
-			err := util.UnmarshalValuesWithJSONPB(tt.valueYAML, &valueStruct)
+			err := util.UnmarshalValuesWithJSONPB(tt.valueYAML, &valueStruct, false)
 			if err != nil {
 				t.Fatalf("unmarshal(%s): got error %s", tt.desc, err)
 			}

--- a/pkg/util/yaml.go
+++ b/pkg/util/yaml.go
@@ -97,12 +97,12 @@ func UnmarshalWithJSONPB(y string, out proto.Message) error {
 }
 
 // UnmarshalValuesWithJSONPB unmarshals y into out using golang jsonpb.
-func UnmarshalValuesWithJSONPB(y string, out proto.Message) error {
+func UnmarshalValuesWithJSONPB(y string, out proto.Message, allowUnknown bool) error {
 	jb, err := yaml.YAMLToJSON([]byte(y))
 	if err != nil {
 		return err
 	}
-	u := jsonpb2.Unmarshaler{AllowUnknownFields: false}
+	u := jsonpb2.Unmarshaler{AllowUnknownFields: allowUnknown}
 	err = u.Unmarshal(bytes.NewReader(jb), out)
 	if err != nil {
 		return err

--- a/pkg/validate/validate_values.go
+++ b/pkg/validate/validate_values.go
@@ -38,7 +38,7 @@ func CheckValues(root map[string]interface{}) util.Errors {
 		return util.Errors{err}
 	}
 	val := &v1alpha1.Values{}
-	if err := util.UnmarshalValuesWithJSONPB(string(vs), val); err != nil {
+	if err := util.UnmarshalValuesWithJSONPB(string(vs), val, false); err != nil {
 		return util.Errors{err}
 	}
 	return validateValues(root, nil)

--- a/scripts/run_migrate_profile.sh
+++ b/scripts/run_migrate_profile.sh
@@ -45,10 +45,18 @@ export GO111MODULE=on
 # and the diff with current profile as reference to update.
 function run_migrate_command() {
     local profile="${1}"
-    local out_profile_path="${OUT}/profiles/${profile}"
+    local out_profile_migrated="${OUT}/${profile}_migrated.yaml"
+    local local_profile="${ROOT}/data/profiles/${profile}.yaml"
+    local out_diff="${OUT}/${profile}_diff"
     mkdir -p "${OUT}/profiles"
-    go run ./cmd/mesh.go manifest migrate "${CHARTS_DIR}" > "${out_profile_path}"
-    go run ./cmd/mesh.go manifest diff "${out_profile_path}" "${ROOT}/data/profiles/${profile}.yaml"
+    go run ./cmd/mesh.go manifest migrate "${CHARTS_DIR}" > "${out_profile_migrated}"
+    status=0
+    go run ./cmd/mesh.go profile diff "${out_profile_migrated}" "${local_profile}" > "${out_diff}" || status=1
+    if [ "${status}" -eq 1 ];then
+      echo "diff output to ${out_diff}"
+    else
+      echo "No diff found"
+    fi
 }
 
 # check the default profile.


### PR DESCRIPTION
changes include:
1. Update the manifest migrate command output to be IstioControlPlane format instead of IstioControlPlaneSpec for easier comparison
2. Update scaleTargetRef reverse translation to work for gateways and mixer part.
3. Update run_migrate_profile.sh to use manifest profile diff command to generate the difference instead of using manifest diff
4. Update UnmarshalValuesWithJSONPB to take in params to decide whether to allowUnknownFields, previously it is hardcoded as true or false.