### PR TITLE
Remove original cr yaml from error message

### DIFF
--- a/cmd/mesh/profile-dump.go
+++ b/cmd/mesh/profile-dump.go
@@ -236,11 +236,11 @@ func unmarshalAndValidateICP(crYAML string, force bool) (*v1alpha2.IstioControlP
 	}
 	icps, _, err := manifest.ParseK8SYAMLToIstioControlPlaneSpec(crYAML)
 	if err != nil {
-		return nil, "", fmt.Errorf("could not unmarshal the overlay file: %s\n\nOriginal YAML:\n%s", err, crYAML)
+		return nil, "", fmt.Errorf("could not unmarshal the overlay file: %s\n", err)
 	}
 	if errs := validate.CheckIstioControlPlaneSpec(icps, false); len(errs) != 0 {
 		if !force {
-			return nil, "", fmt.Errorf("input file failed validation with the following errors: %s\n\nOriginal YAML:\n%s", errs, crYAML)
+			return nil, "", fmt.Errorf("input file failed validation with the following errors: %s\n", errs)
 		}
 	}
 	icpsYAML, err := util.MarshalWithJSONPB(icps)

--- a/cmd/mesh/profile-dump.go
+++ b/cmd/mesh/profile-dump.go
@@ -236,11 +236,11 @@ func unmarshalAndValidateICP(crYAML string, force bool) (*v1alpha2.IstioControlP
 	}
 	icps, _, err := manifest.ParseK8SYAMLToIstioControlPlaneSpec(crYAML)
 	if err != nil {
-		return nil, "", fmt.Errorf("could not unmarshal the overlay file: %s\n", err)
+		return nil, "", fmt.Errorf("could not unmarshal the overlay file: %s", err)
 	}
 	if errs := validate.CheckIstioControlPlaneSpec(icps, false); len(errs) != 0 {
 		if !force {
-			return nil, "", fmt.Errorf("input file failed validation with the following errors: %s\n", errs)
+			return nil, "", fmt.Errorf("input file failed validation with the following errors: %s", errs)
 		}
 	}
 	icpsYAML, err := util.MarshalWithJSONPB(icps)


### PR DESCRIPTION
The reason why I propose this change is because usually the original cr yaml is really large, making it hard to see the actual error message from the output, also user can just refer to input file instead of looking into the output for the cr content.

ok there has been a recent change to dump the output to stderr instead, but still I think it increases complexity for debugging