### PR TITLE
Simplify and improve the user facing outputs.

### DIFF
--- a/cmd/mesh/manifest-apply.go
+++ b/cmd/mesh/manifest-apply.go
@@ -67,7 +67,7 @@ func manifestApplyCmd(rootArgs *rootArgs, maArgs *manifestApplyArgs) *cobra.Comm
 		Run: func(cmd *cobra.Command, args []string) {
 			// Passing cmd.OutOrStdXXX() allows capturing command output for e2e tests.
 			l := newLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.OutOrStderr())
-			// Warn a user if they type `mesh manifest apply` without any config args.
+			// Warn users if they use `manifest apply` without any config args.
 			if maArgs.inFilename == "" && len(maArgs.set) == 0 && !maArgs.skipConfirmation {
 				if !confirm("This will install the default Istio profile into the cluster. Proceed? (y/N)", cmd.OutOrStdout()) {
 					cmd.Print("Cancelled.\n")

--- a/cmd/mesh/manifest-generate.go
+++ b/cmd/mesh/manifest-generate.go
@@ -72,7 +72,7 @@ func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, l *logger) {
 	if err != nil {
 		l.logAndFatal(err.Error())
 	}
-	manifests, err := genManifests(mgArgs.inFilename, overlayFromSet, mgArgs.force, l)
+	manifests, _, err := genManifests(mgArgs.inFilename, overlayFromSet, mgArgs.force, l)
 	if err != nil {
 		l.logAndFatal(err.Error())
 	}

--- a/pkg/manifest/installer.go
+++ b/pkg/manifest/installer.go
@@ -126,8 +126,7 @@ var (
 	dependencyWaitCh = make(map[name.ComponentName]chan struct{})
 	kubectl          = kubectlcmd.New()
 
-	k8sRESTConfig  *rest.Config
-	appliedObjects = object.K8sObjects{}
+	k8sRESTConfig *rest.Config
 )
 
 func init() {
@@ -219,10 +218,11 @@ type InstallOptions struct {
 
 // ApplyAll applies all given manifests using kubectl client.
 func ApplyAll(manifests name.ManifestMap, version version.Version, opts *InstallOptions) (CompositeOutput, error) {
-	logAndPrint("Applying manifests for these components:")
+	logAndPrint("Preparing manifests for these components:")
 	for c := range manifests {
 		logAndPrint("- %s", c)
 	}
+	logAndPrint("")
 	log.Infof("Component dependencies tree: \n%s", installTreeString())
 	if err := initK8SRestClient(opts.Kubeconfig, opts.Context); err != nil {
 		return nil, err
@@ -234,19 +234,21 @@ func applyRecursive(manifests name.ManifestMap, version version.Version, opts *I
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	out := CompositeOutput{}
+	allAppliedObjects := object.K8sObjects{}
 	for c, m := range manifests {
 		c := c
 		m := m
 		wg.Add(1)
 		go func() {
 			if s := dependencyWaitCh[c]; s != nil {
-				logAndPrint("%s is waiting on a prerequisite...", c)
+				log.Infof("%s is waiting on a prerequisite...", c)
 				<-s
-				logAndPrint("Prerequisite for %s has completed, proceeding with install.", c)
+				log.Infof("Prerequisite for %s has completed, proceeding with install.", c)
 			}
-			applyOut := applyManifest(c, m, version, opts)
+			applyOut, appliedObjects := applyManifest(c, m, version, opts)
 			mu.Lock()
 			out[c] = applyOut
+			allAppliedObjects = append(allAppliedObjects, appliedObjects...)
 			mu.Unlock()
 
 			// Signal all the components that depend on us.
@@ -259,18 +261,19 @@ func applyRecursive(manifests name.ManifestMap, version version.Version, opts *I
 	}
 	wg.Wait()
 	if opts.Wait {
-		return out, waitForResources(appliedObjects, opts)
+		return out, waitForResources(allAppliedObjects, opts)
 	}
 	return out, nil
 }
 
-func applyManifest(componentName name.ComponentName, manifestStr string, version version.Version, opts *InstallOptions) *ComponentApplyOutput {
+func applyManifest(componentName name.ComponentName, manifestStr string, version version.Version,
+	opts *InstallOptions) (*ComponentApplyOutput, object.K8sObjects) {
 	stdout, stderr := "", ""
+	appliedObjects := object.K8sObjects{}
 	objects, err := object.ParseK8sObjectsFromYAMLManifest(manifestStr)
 	if err != nil {
-		return buildComponentApplyOutput(stdout, stderr, "", err)
+		return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 	}
-
 	componentLabel := fmt.Sprintf("%s=%s", istioComponentLabelStr, componentName)
 
 	// TODO: remove this when `kubectl --prune` supports empty objects
@@ -279,15 +282,29 @@ func applyManifest(componentName name.ComponentName, manifestStr string, version
 	if len(objects) == 0 {
 		extraArgsGet := []string{"--all-namespaces", "--selector", componentLabel}
 		stdoutGet, stderrGet, err := kubectl.GetAll(opts.Kubeconfig, opts.Context, "", "yaml", extraArgsGet...)
-		if err != nil || strings.TrimSpace(stdoutGet) == "" {
-			return buildComponentApplyOutput(stdoutGet, stderrGet, "", err)
+		if err != nil {
+			stdout += "\n" + stdoutGet
+			stderr += "\n" + stderrGet
+			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
+		}
+		items, err := GetKubectlGetItems(stdoutGet)
+		if err != nil {
+			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
+		}
+		if len(items) == 0 {
+			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 		}
 
 		extraArgsDel := []string{"--selector", componentLabel}
 		stdoutDel, stderrDel, err := kubectl.Delete(opts.DryRun, opts.Verbose, opts.Kubeconfig, opts.Context, "", stdoutGet, extraArgsDel...)
 		stdout += "\n" + stdoutDel
 		stderr += "\n" + stderrDel
-		return buildComponentApplyOutput(stdout, stderr, "", err)
+		delObjects, err := object.ParseK8sObjectsFromYAMLManifest(stdoutGet)
+		if err != nil {
+			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
+		}
+		appliedObjects = append(appliedObjects, delObjects...)
+		return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 	}
 
 	namespace := ""
@@ -302,8 +319,6 @@ func applyManifest(componentName name.ComponentName, manifestStr string, version
 	}
 	objects.Sort(defaultObjectOrder())
 
-	appliedObjects = append(appliedObjects, objects...)
-
 	extraArgs := []string{"--force"}
 	// Base components include namespaces and CRDs, pruning them will remove user configs, which makes it hard to roll back.
 	if componentName != name.IstioBaseComponentName {
@@ -316,54 +331,76 @@ func applyManifest(componentName name.ComponentName, manifestStr string, version
 	if len(nsObjects) > 0 {
 		mns, err := nsObjects.JSONManifest()
 		if err != nil {
-			return buildComponentApplyOutput(stdout, stderr, "", err)
+			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 		}
 
 		stdoutNs, stderrNs, err := kubectl.Apply(opts.DryRun, opts.Verbose, opts.Kubeconfig, opts.Context, namespace, mns, extraArgs...)
 		stdout += "\n" + stdoutNs
 		stderr += "\n" + stderrNs
 		if err != nil {
-			return buildComponentApplyOutput(stdout, stderr, "", err)
+			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 		}
 
 		if err := waitForResources(nsObjects, opts); err != nil {
-			return buildComponentApplyOutput(stdout, stderr, "", err)
+			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 		}
 	}
+	appliedObjects = append(appliedObjects, nsObjects...)
 
 	crdObjects := cRDKindObjects(objects)
 	if len(crdObjects) > 0 {
 		mcrd, err := crdObjects.JSONManifest()
 		if err != nil {
-			return buildComponentApplyOutput(stdout, stderr, "", err)
+			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 		}
 
 		stdoutCRD, stderrCRD, err := kubectl.Apply(opts.DryRun, opts.Verbose, opts.Kubeconfig, opts.Context, namespace, mcrd, extraArgs...)
 		stdout += "\n" + stdoutCRD
 		stderr += "\n" + stderrCRD
 		if err != nil {
-			return buildComponentApplyOutput(stdout, stderr, "", err)
+			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 		}
 		// Not all Istio components are robust to not yet created CRDs.
 		if err := waitForCRDs(objects, opts.DryRun); err != nil {
-			return buildComponentApplyOutput(stdout, stderr, "", err)
+			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 		}
 	}
+	appliedObjects = append(appliedObjects, crdObjects...)
 
 	nonNsCrdObjects := objectsNotInLists(objects, nsObjects, crdObjects)
 	m, err := nonNsCrdObjects.JSONManifest()
 	if err != nil {
-		return buildComponentApplyOutput(stdout, stderr, "", err)
+		return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 	}
 	stdoutNonNsCrd, stderrNonNsCrd, err := kubectl.Apply(opts.DryRun, opts.Verbose, opts.Kubeconfig, opts.Context, namespace, m, extraArgs...)
 	stdout += "\n" + stdoutNonNsCrd
 	stderr += "\n" + stderrNonNsCrd
 	logAndPrint("Finished applying manifest for component %s", componentName)
-	ym, _ := objects.YAMLManifest()
-	return buildComponentApplyOutput(stdout, stderr, ym, err)
+	appliedObjects = append(appliedObjects, nonNsCrdObjects...)
+	return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 }
 
-func buildComponentApplyOutput(stdout string, stderr string, manifest string, err error) *ComponentApplyOutput {
+func GetKubectlGetItems(stdoutGet string) ([]interface{}, error) {
+	yamlGet := make(map[string]interface{})
+	err := yaml.Unmarshal([]byte(stdoutGet), &yamlGet)
+	if err != nil {
+		return nil, err
+	}
+	if yamlGet["kind"] != "List" {
+		return nil, fmt.Errorf("`kubectl get` returned a yaml whose kind is not List")
+	}
+	if _, ok := yamlGet["items"]; !ok {
+		return nil, fmt.Errorf("`kubectl get` returned a yaml without 'items' in the root")
+	}
+	switch items := yamlGet["items"].(type) {
+	case []interface{}:
+		return items, nil
+	}
+	return nil, fmt.Errorf("`kubectl get` returned a yaml incorrecnt type 'items' in the root")
+}
+
+func buildComponentApplyOutput(stdout string, stderr string, objects object.K8sObjects, err error) *ComponentApplyOutput {
+	manifest, _ := objects.YAMLManifest()
 	return &ComponentApplyOutput{
 		Stdout:   stdout,
 		Stderr:   stderr,
@@ -448,11 +485,11 @@ func objectsNotInLists(objects object.K8sObjects, lists ...object.K8sObjects) ob
 
 func waitForCRDs(objects object.K8sObjects, dryRun bool) error {
 	if dryRun {
-		logAndPrint("Not waiting for CRDs in dry run mode.")
+		log.Info("Not waiting for CRDs in dry run mode.")
 		return nil
 	}
 
-	logAndPrint("Waiting for CRDs to be applied.")
+	log.Info("Waiting for CRDs to be applied.")
 	cs, err := apiextensionsclient.NewForConfig(k8sRESTConfig)
 	if err != nil {
 		return fmt.Errorf("k8s client error: %s", err)
@@ -490,11 +527,11 @@ func waitForCRDs(objects object.K8sObjects, dryRun bool) error {
 	})
 
 	if errPoll != nil {
-		logAndPrint("failed to verify CRD creation; %s", errPoll)
+		log.Errorf("failed to verify CRD creation; %s", errPoll)
 		return fmt.Errorf("failed to verify CRD creation: %s", errPoll)
 	}
 
-	logAndPrint("CRDs applied.")
+	log.Info("Finished applying CRDs.")
 	return nil
 }
 

--- a/pkg/manifest/installer.go
+++ b/pkg/manifest/installer.go
@@ -295,11 +295,14 @@ func applyManifest(componentName name.ComponentName, manifestStr string, version
 			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 		}
 
+		delObjects, err := object.ParseK8sObjectsFromYAMLManifest(stdoutGet)
+		if err != nil {
+			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
+		}
 		extraArgsDel := []string{"--selector", componentLabel}
 		stdoutDel, stderrDel, err := kubectl.Delete(opts.DryRun, opts.Verbose, opts.Kubeconfig, opts.Context, "", stdoutGet, extraArgsDel...)
 		stdout += "\n" + stdoutDel
 		stderr += "\n" + stderrDel
-		delObjects, err := object.ParseK8sObjectsFromYAMLManifest(stdoutGet)
 		if err != nil {
 			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 		}


### PR DESCRIPTION
Fix: https://github.com/istio/istio/issues/18892

Sample output:
```
$ go build -o /usr/local/google/home/taohe/go/bin/mesh ./cmd/mesh.go ; mesh manifest apply
This will install the default Istio profile into the cluster. Proceed? (y/N) y
Preparing manifests for these components:
- Prometheus
- Tracing
- PrometheusOperator
- Policy
- CoreDNS
- Injector
- Pilot
- IngressGateway
- Cni
- Galley
- Grafana
- CertManager
- Telemetry
- EgressGateway
- NodeAgent
- Base
- Citadel
- Kiali

Applying manifest for component Base
Finished applying manifest for component Base
Applying manifest for component Prometheus
Applying manifest for component IngressGateway
Applying manifest for component Policy
Applying manifest for component Galley
Applying manifest for component Pilot
Applying manifest for component Citadel
Applying manifest for component Telemetry
Applying manifest for component Injector
Finished applying manifest for component Prometheus
Finished applying manifest for component Citadel
Finished applying manifest for component Policy
Finished applying manifest for component IngressGateway
Finished applying manifest for component Galley
Finished applying manifest for component Pilot
Finished applying manifest for component Injector
Finished applying manifest for component Telemetry

Component Injector - manifest apply finished successfully:
==========================================================

serviceaccount/istio-sidecar-injector-service-account created
clusterrole.rbac.authorization.k8s.io/istio-sidecar-injector-istio-system created
clusterrolebinding.rbac.authorization.k8s.io/istio-sidecar-injector-admin-role-binding-istio-system created
configmap/injector-mesh created
configmap/istio-sidecar-injector created
mutatingwebhookconfiguration.admissionregistration.k8s.io/istio-sidecar-injector created
deployment.apps/istio-sidecar-injector created
poddisruptionbudget.policy/istio-sidecar-injector created
service/istio-sidecar-injector created



Component Pilot - manifest apply finished successfully:
=======================================================

serviceaccount/istio-pilot-service-account created
clusterrole.rbac.authorization.k8s.io/istio-pilot-istio-system created
clusterrolebinding.rbac.authorization.k8s.io/istio-pilot-istio-system created
configmap/istio created
configmap/pilot-envoy-config created
deployment.apps/istio-pilot created
meshpolicy.authentication.istio.io/default created
poddisruptionbudget.policy/istio-pilot created
horizontalpodautoscaler.autoscaling/istio-pilot created
service/istio-pilot created



Component IngressGateway - manifest apply finished successfully:
================================================================

serviceaccount/istio-ingressgateway-service-account created
deployment.apps/istio-ingressgateway created
gateway.networking.istio.io/ingressgateway created
sidecar.networking.istio.io/default created
poddisruptionbudget.policy/ingressgateway created
horizontalpodautoscaler.autoscaling/istio-ingressgateway created
service/istio-ingressgateway created



Component Galley - manifest apply finished successfully:
========================================================

serviceaccount/istio-galley-service-account created
clusterrole.rbac.authorization.k8s.io/istio-galley-istio-system created
clusterrolebinding.rbac.authorization.k8s.io/istio-galley-admin-role-binding-istio-system created
configmap/galley-envoy-config created
configmap/istio-galley-configuration created
configmap/istio-mesh-galley created
deployment.apps/istio-galley created
poddisruptionbudget.policy/istio-galley created
service/istio-galley created



Component Telemetry - manifest apply finished successfully:
===========================================================

serviceaccount/istio-mixer-service-account created
clusterrole.rbac.authorization.k8s.io/istio-mixer-istio-system created
clusterrolebinding.rbac.authorization.k8s.io/istio-mixer-admin-role-binding-istio-system created
configmap/telemetry-envoy-config created
deployment.apps/istio-telemetry created
attributemanifest.config.istio.io/istioproxy created
attributemanifest.config.istio.io/kubernetes created
handler.config.istio.io/kubernetesenv created
handler.config.istio.io/prometheus created
instance.config.istio.io/attributes created
instance.config.istio.io/requestcount created
instance.config.istio.io/requestduration created
instance.config.istio.io/requestsize created
instance.config.istio.io/responsesize created
instance.config.istio.io/tcpbytereceived created
instance.config.istio.io/tcpbytesent created
instance.config.istio.io/tcpconnectionsclosed created
instance.config.istio.io/tcpconnectionsopened created
rule.config.istio.io/kubeattrgenrulerule created
rule.config.istio.io/promhttp created
rule.config.istio.io/promtcp created
rule.config.istio.io/promtcpconnectionclosed created
rule.config.istio.io/promtcpconnectionopen created
rule.config.istio.io/tcpkubeattrgenrulerule created
destinationrule.networking.istio.io/istio-telemetry created
poddisruptionbudget.policy/istio-telemetry created
horizontalpodautoscaler.autoscaling/istio-telemetry created
service/istio-telemetry created



Component Base - manifest apply finished successfully:
======================================================

namespace/istio-system created

customresourcedefinition.apiextensions.k8s.io/adapters.config.istio.io created
customresourcedefinition.apiextensions.k8s.io/attributemanifests.config.istio.io created
customresourcedefinition.apiextensions.k8s.io/authorizationpolicies.security.istio.io created
customresourcedefinition.apiextensions.k8s.io/clusterrbacconfigs.rbac.istio.io created
customresourcedefinition.apiextensions.k8s.io/destinationrules.networking.istio.io created
customresourcedefinition.apiextensions.k8s.io/envoyfilters.networking.istio.io created
customresourcedefinition.apiextensions.k8s.io/gateways.networking.istio.io created
customresourcedefinition.apiextensions.k8s.io/handlers.config.istio.io created
customresourcedefinition.apiextensions.k8s.io/httpapispecbindings.config.istio.io created
customresourcedefinition.apiextensions.k8s.io/httpapispecs.config.istio.io created
customresourcedefinition.apiextensions.k8s.io/instances.config.istio.io created
customresourcedefinition.apiextensions.k8s.io/meshpolicies.authentication.istio.io created
customresourcedefinition.apiextensions.k8s.io/policies.authentication.istio.io created
customresourcedefinition.apiextensions.k8s.io/quotaspecbindings.config.istio.io created
customresourcedefinition.apiextensions.k8s.io/quotaspecs.config.istio.io created
customresourcedefinition.apiextensions.k8s.io/rbacconfigs.rbac.istio.io created
customresourcedefinition.apiextensions.k8s.io/requestauthentications.security.istio.io created
customresourcedefinition.apiextensions.k8s.io/rules.config.istio.io created
customresourcedefinition.apiextensions.k8s.io/serviceentries.networking.istio.io created
customresourcedefinition.apiextensions.k8s.io/servicerolebindings.rbac.istio.io created
customresourcedefinition.apiextensions.k8s.io/serviceroles.rbac.istio.io created
customresourcedefinition.apiextensions.k8s.io/sidecars.networking.istio.io created
customresourcedefinition.apiextensions.k8s.io/templates.config.istio.io created
customresourcedefinition.apiextensions.k8s.io/virtualservices.networking.istio.io created

serviceaccount/istio-reader-service-account created
clusterrole.rbac.authorization.k8s.io/istio-reader-istio-system created
clusterrolebinding.rbac.authorization.k8s.io/istio-reader-istio-system created



Component Citadel - manifest apply finished successfully:
=========================================================

serviceaccount/istio-citadel-service-account created
clusterrole.rbac.authorization.k8s.io/istio-citadel-istio-system created
clusterrolebinding.rbac.authorization.k8s.io/istio-citadel-istio-system created
deployment.apps/istio-citadel created
poddisruptionbudget.policy/istio-citadel created
service/istio-citadel created



Component Prometheus - manifest apply finished successfully:
============================================================

serviceaccount/prometheus created
clusterrole.rbac.authorization.k8s.io/prometheus-istio-system created
clusterrolebinding.rbac.authorization.k8s.io/prometheus-istio-system created
configmap/prometheus created
deployment.apps/prometheus created
service/prometheus created



Component Policy - manifest apply finished successfully:
========================================================

serviceaccount/istio-policy-service-account created
clusterrole.rbac.authorization.k8s.io/istio-policy created
clusterrolebinding.rbac.authorization.k8s.io/istio-policy-admin-role-binding-istio-system created
deployment.apps/istio-policy created
destinationrule.networking.istio.io/istio-policy created
poddisruptionbudget.policy/istio-policy created
horizontalpodautoscaler.autoscaling/istio-policy created
service/istio-policy created




*** Success ***

```