### PR TITLE
Use RunE for cobra commands

### DIFF
--- a/cmd/mesh/manifest-generate.go
+++ b/cmd/mesh/manifest-generate.go
@@ -55,26 +55,25 @@ func manifestGenerateCmd(rootArgs *rootArgs, mgArgs *manifestGenerateArgs) *cobr
 			}
 			return nil
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			l := newLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.OutOrStderr())
-			manifestGenerate(rootArgs, mgArgs, l)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			l := newLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.ErrOrStderr())
+			return manifestGenerate(rootArgs, mgArgs, l)
 		}}
 
 }
 
-func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, l *logger) {
+func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, l *logger) error {
 	if err := configLogs(args.logToStdErr); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Could not configure logs: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not configure logs: %s", err)
 	}
 
 	overlayFromSet, err := makeTreeFromSetList(mgArgs.set, mgArgs.force, l)
 	if err != nil {
-		l.logAndFatal(err.Error())
+		return err
 	}
 	manifests, err := genManifests(mgArgs.inFilename, overlayFromSet, mgArgs.force, l)
 	if err != nil {
-		l.logAndFatal(err.Error())
+		return err
 	}
 
 	if mgArgs.outFilename == "" {
@@ -83,12 +82,14 @@ func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, l *logger) {
 		}
 	} else {
 		if err := os.MkdirAll(mgArgs.outFilename, os.ModePerm); err != nil {
-			l.logAndFatal(err.Error())
+			return err
 		}
 		if err := manifest.RenderToDir(manifests, mgArgs.outFilename, args.dryRun); err != nil {
-			l.logAndFatal(err.Error())
+			return err
 		}
 	}
+
+	return nil
 }
 
 func orderedManifests(mm name.ManifestMap) []string {

--- a/cmd/mesh/manifest-versions.go
+++ b/cmd/mesh/manifest-versions.go
@@ -55,18 +55,18 @@ func manifestVersionsCmd(rootArgs *rootArgs, versionsArgs *manifestVersionsArgs)
 			}
 			return nil
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			l := newLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.OutOrStderr())
-			manifestVersions(rootArgs, versionsArgs, l)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			l := newLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.ErrOrStderr())
+			return manifestVersions(rootArgs, versionsArgs, l)
 		}}
 }
 
-func manifestVersions(args *rootArgs, mvArgs *manifestVersionsArgs, l *logger) {
+func manifestVersions(args *rootArgs, mvArgs *manifestVersionsArgs, l *logger) error {
 	initLogsOrExit(args)
 
 	myVersionMap, err := getVersionCompatibleMap(mvArgs.versionsURI, binversion.OperatorBinaryGoVersion, l)
 	if err != nil {
-		l.logAndFatalf("Failed to retrieve version map, error: %v", err)
+		return fmt.Errorf("failed to retrieve version map, error: %v", err)
 	}
 
 	fmt.Print("\nOperator version is ", binversion.OperatorBinaryGoVersion.String(), ".\n\n")
@@ -79,6 +79,8 @@ func manifestVersions(args *rootArgs, mvArgs *manifestVersionsArgs, l *logger) {
 		fmt.Printf("  %s\n", v.String())
 	}
 	fmt.Println()
+
+	return nil
 }
 
 func getVersionCompatibleMap(versionsURI string, binVersion *goversion.Version,

--- a/cmd/mesh/profile-dump.go
+++ b/cmd/mesh/profile-dump.go
@@ -48,18 +48,18 @@ func profileDumpCmd(rootArgs *rootArgs, pdArgs *profileDumpArgs) *cobra.Command 
 			}
 			return nil
 		},
-		Run: func(cmd *cobra.Command, args []string) {
-			l := newLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.OutOrStderr())
-			profileDump(args, rootArgs, pdArgs, l)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			l := newLogger(rootArgs.logToStdErr, cmd.OutOrStdout(), cmd.ErrOrStderr())
+			return profileDump(args, rootArgs, pdArgs, l)
 		}}
 
 }
 
-func profileDump(args []string, rootArgs *rootArgs, pdArgs *profileDumpArgs, l *logger) {
+func profileDump(args []string, rootArgs *rootArgs, pdArgs *profileDumpArgs, l *logger) error {
 	initLogsOrExit(rootArgs)
 
 	if len(args) == 1 && pdArgs.inFilename != "" {
-		l.logAndFatal("Cannot specify both profile name and filename flag.")
+		return fmt.Errorf("cannot specify both profile name and filename flag")
 	}
 
 	profile := ""
@@ -68,8 +68,10 @@ func profileDump(args []string, rootArgs *rootArgs, pdArgs *profileDumpArgs, l *
 	}
 	y, err := genProfile(pdArgs.helmValues, pdArgs.inFilename, profile, "", pdArgs.configPath, true, l)
 	if err != nil {
-		l.logAndFatal(err.Error())
+		return err
 	}
 
 	l.print(y + "\n")
+
+	return nil
 }

--- a/cmd/mesh/profile-list.go
+++ b/cmd/mesh/profile-list.go
@@ -28,14 +28,14 @@ func profileListCmd(rootArgs *rootArgs) *cobra.Command {
 		Short: "Lists available Istio configuration profiles",
 		Long:  "The list subcommand lists the available Istio configuration profiles.",
 		Args:  cobra.ExactArgs(0),
-		Run: func(cmd *cobra.Command, args []string) {
-			profileList(rootArgs)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return profileList(rootArgs)
 		}}
 
 }
 
 // profileList list all the builtin profiles.
-func profileList(args *rootArgs) {
+func profileList(args *rootArgs) error {
 	initLogsOrExit(args)
 	profiles := helm.ListBuiltinProfiles()
 	if len(profiles) == 0 {
@@ -46,4 +46,6 @@ func profileList(args *rootArgs) {
 			fmt.Printf("    %s\n", profile)
 		}
 	}
+
+	return nil
 }

--- a/cmd/mesh/shared.go
+++ b/cmd/mesh/shared.go
@@ -96,11 +96,6 @@ func (l *logger) logAndError(v ...interface{}) {
 	}
 }
 
-func (l *logger) logAndFatal(v ...interface{}) {
-	l.logAndError(v...)
-	os.Exit(-1)
-}
-
 func (l *logger) logAndPrintf(format string, a ...interface{}) {
 	s := fmt.Sprintf(format, a...)
 	if !l.logToStdErr {


### PR DESCRIPTION
This gives us more control of the output.

In cases where we supply stdOut and stdErr (test cases), if
we abort the execution upon an error, the caller does not
have the chance to collect the output and print to user.

By using `RunE` instead of `Run` we don't need to abort
the execution and therefore break the workflow. By returning
an error the caller can properly handle the error.