### PR TITLE
Disable leader election when LEADER_ELECTION_NAMESPACE is not set

### DIFF
--- a/cmd/manager/server.go
+++ b/cmd/manager/server.go
@@ -81,12 +81,8 @@ func getWatchNamespace() (string, error) {
 }
 
 // getLeaderElectionNamespace returns the namespace in which the leader election configmap will be created
-func getLeaderElectionNamespace() (string, error) {
-	ns, found := os.LookupEnv("LEADER_ELECTION_NAMESPACE")
-	if !found {
-		return "", fmt.Errorf("LEADER_ELECTION_NAMESPACE must be set")
-	}
-	return ns, nil
+func getLeaderElectionNamespace() (string, bool) {
+	return os.LookupEnv("LEADER_ELECTION_NAMESPACE")
 }
 
 func run() {
@@ -95,9 +91,9 @@ func run() {
 		log.Fatalf("Failed to get watch namespace: %v", err)
 	}
 
-	leaderElectionNS, err := getLeaderElectionNamespace()
-	if err != nil {
-		log.Fatalf("Failed to get leader election namespace: %v", err)
+	leaderElectionNS, leaderElectionEnabled := getLeaderElectionNamespace()
+	if !leaderElectionEnabled {
+		log.Warn("Leader election namespace not set. Leader election is disabled.")
 	}
 
 	// Get a config to talk to the apiserver
@@ -112,7 +108,7 @@ func run() {
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 		// Workaround for https://github.com/kubernetes-sigs/controller-runtime/issues/321
 		MapperProvider:          drm.NewDynamicRESTMapper,
-		LeaderElection:          true,
+		LeaderElection:          leaderElectionEnabled,
 		LeaderElectionNamespace: leaderElectionNS,
 		LeaderElectionID:        "istio-operator-lock",
 	})

--- a/cmd/manager/server.go
+++ b/cmd/manager/server.go
@@ -93,7 +93,7 @@ func run() {
 
 	leaderElectionNS, leaderElectionEnabled := getLeaderElectionNamespace()
 	if !leaderElectionEnabled {
-		log.Warn("Leader election namespace not set. Leader election is disabled.")
+		log.Warn("Leader election namespace not set. Leader election is disabled. NOT APPROPRIATE FOR PRODUCTION USE!")
 	}
 
 	// Get a config to talk to the apiserver


### PR DESCRIPTION
Debugging the controller is practically impossible, since it loses
the leader election lock when it's suspended for too long. This causes
the process to be terminated.