### PR TITLE
Fix minimal values-test file

### DIFF
--- a/tests/profiles/helm/values-istio-minimal.yaml
+++ b/tests/profiles/helm/values-istio-minimal.yaml
@@ -34,6 +34,7 @@ global:
   # Telemetry namespace, including tracing.
   telemetryNamespace: istio-system
   policyNamespace: istio-system
+  controlPlaneSecurityEnabled: false
 
   proxy:
     # Sets the destination Statsd in envoy (the value of the "--statsdUdpAddress" proxy argument


### PR DESCRIPTION
The minimal profile set `controlPlaneSecurityEnabled` to false, but the values-test file doesn't have it (default to true from global.yaml), which can make `mandiff` fail if someone makes changes related to `controlPlaneSecurityEnabled` in istio/installer. This change has been merged into 1.4 #662