### PR TITLE
Fix parse objects from yaml

### DIFF
--- a/pkg/object/objects.go
+++ b/pkg/object/objects.go
@@ -218,7 +218,7 @@ func ParseK8sObjectsFromYAMLManifest(manifest string) (K8sObjects, error) {
 	scanner := bufio.NewScanner(strings.NewReader(manifest))
 	for scanner.Scan() {
 		line := scanner.Text()
-		if line == "---" {
+		if strings.TrimSpace(line) == "---" {
 			// yaml separator
 			yamls = append(yamls, b.String())
 			b.Reset()


### PR DESCRIPTION
fix https://github.com/istio/istio/issues/19371 and there might be some other issues caused by it. Without this change it is possible that two k8s yamls would treated as one and only the first object get parsed.