### PR TITLE
upgrade cmd: using ICPS to compare changes between current install and target install.

### DIFF
--- a/cmd/mesh/manifest-generate_test.go
+++ b/cmd/mesh/manifest-generate_test.go
@@ -164,7 +164,7 @@ func TestLDFlags(t *testing.T) {
 	version.DockerInfo.Hub = "testHub"
 	version.DockerInfo.Tag = "testTag"
 	l := NewLogger(true, os.Stdout, os.Stderr)
-	_, icps, err := genICPS("", "default", "", true, l)
+	_, icps, err := genICPS("", "default", "", "", true, l)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/mesh/upgrade.go
+++ b/cmd/mesh/upgrade.go
@@ -181,8 +181,8 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l *Logger) (err error) {
 
 	// Run pre-upgrade hooks
 	hparams := &hooks.HookCommonParams{
-		SourceVer:    currentVersion,
-		TargetVer:    targetVersion,
+		SourceVer:  currentVersion,
+		TargetVer:  targetVersion,
 		SourceICPS: targetICPS,
 		TargetICPS: targetICPS,
 	}

--- a/cmd/mesh/upgrade.go
+++ b/cmd/mesh/upgrade.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ghodss/yaml"
 	goversion "github.com/hashicorp/go-version"
 	"github.com/spf13/cobra"
 
@@ -249,36 +248,6 @@ func waitForConfirmation(skipConfirmation bool, l *Logger) {
 	if !confirm("Confirm to proceed [y/N]?", os.Stdout) {
 		l.logAndFatalf("Abort.")
 	}
-}
-
-// readValuesFromInjectorConfigMap reads the values from the config map of sidecar-injector.
-func readValuesFromInjectorConfigMap(kubeClient manifest.ExecClient, istioNamespace string) (string, error) {
-	configMapList, err := kubeClient.ConfigMapForSelector(istioNamespace, "istio=sidecar-injector")
-	if err != nil || len(configMapList.Items) == 0 {
-		return "", fmt.Errorf("failed to retrieve sidecar-injector config map: %v", err)
-	}
-
-	jsonValues := ""
-	foundValues := false
-	for _, item := range configMapList.Items {
-		if item.Name == "istio-sidecar-injector" && item.Data != nil {
-			jsonValues, foundValues = item.Data["values"]
-			if foundValues {
-				break
-			}
-		}
-	}
-
-	if !foundValues {
-		return "", fmt.Errorf("failed to find values in sidecar-injector config map: %v", configMapList)
-	}
-
-	yamlValues, err := yaml.JSONToYAML([]byte(jsonValues))
-	if err != nil {
-		return "", fmt.Errorf("jsonToYAML failed to parse values:\n%v\nError:\n%v", yamlValues, err)
-	}
-
-	return string(yamlValues), nil
 }
 
 // checkSupportedVersions checks if the upgrade cur -> tar is supported by the tool

--- a/cmd/mesh/upgrade.go
+++ b/cmd/mesh/upgrade.go
@@ -169,8 +169,10 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l *Logger) (err error) {
 		return fmt.Errorf("failed to generate override values from file: %v, error: %v", args.inFilename, err)
 	}
 
-	// Generates ICPS for args.inFilename ICP specs yaml
-	currentICPSYaml, _, err := genICPS(args.inFilename, "", "", currentVersion, args.force, l)
+	// Generates ICPS for args.inFilename ICP specs yaml. Param force is set to true to
+	// skip the validation because the code only has the validation proto for the
+	// target version.
+	currentICPSYaml, _, err := genICPS(args.inFilename, "", "", currentVersion, true, l)
 	if err != nil {
 		return fmt.Errorf("failed to generate ICPS from file: %s for the current version: %s, error: %v",
 			args.inFilename, currentVersion, err)

--- a/pkg/helm/urlfetcher.go
+++ b/pkg/helm/urlfetcher.go
@@ -40,6 +40,8 @@ const (
 	InstallationDirectory = "istio-install-packages"
 	// ChartsFilePath is file path of installation packages to helm charts.
 	ChartsFilePath = "install/kubernetes/operator/charts"
+	// ProfilesFilePath is file path of installation packages to profiles.
+	ProfilesFilePath = "install/kubernetes/operator/profiles"
 	// SHAFileSuffix is the default SHA file suffix
 	SHAFileSuffix = ".sha256"
 )

--- a/pkg/hooks/upgrade_hooks.go
+++ b/pkg/hooks/upgrade_hooks.go
@@ -44,8 +44,8 @@ type hookVersionMapping struct {
 
 // HookCommonParams is a set of common params passed to all hooks.
 type HookCommonParams struct {
-	SourceVer    string
-	TargetVer    string
+	SourceVer  string
+	TargetVer  string
 	SourceICPS *v1alpha2.IstioControlPlaneSpec
 	TargetICPS *v1alpha2.IstioControlPlaneSpec
 }

--- a/pkg/hooks/upgrade_hooks.go
+++ b/pkg/hooks/upgrade_hooks.go
@@ -31,7 +31,7 @@ import (
 
 // hook is a callout function that may be called during an upgrade to check state or modify the cluster.
 // hooks should only be used for version-specific actions.
-type hook func(kubeClient manifest.ExecClient, sourceValues, targetValues *v1alpha2.IstioControlPlaneSpec) util.Errors
+type hook func(kubeClient manifest.ExecClient, sourceICPS, targetICPS *v1alpha2.IstioControlPlaneSpec) util.Errors
 type hooks []hook
 
 // hookVersionMapping is a mapping between a hashicorp/go-version formatted constraints for the source and target
@@ -46,8 +46,8 @@ type hookVersionMapping struct {
 type HookCommonParams struct {
 	SourceVer    string
 	TargetVer    string
-	SourceValues *v1alpha2.IstioControlPlaneSpec
-	TargetValues *v1alpha2.IstioControlPlaneSpec
+	SourceICPS *v1alpha2.IstioControlPlaneSpec
+	TargetICPS *v1alpha2.IstioControlPlaneSpec
 }
 
 var (
@@ -102,7 +102,7 @@ func runUpgradeHooks(hml []hookVersionMapping, kubeClient manifest.ExecClient, h
 		}
 		for _, hf := range h.hooks {
 			log.Infof("Running hook %s", hf)
-			errs = util.AppendErrs(errs, hf(kubeClient, hc.SourceValues, hc.TargetValues))
+			errs = util.AppendErrs(errs, hf(kubeClient, hc.SourceICPS, hc.TargetICPS))
 		}
 	}
 	return errs
@@ -145,8 +145,8 @@ func checkConstraint(verStr, constraintStr string) (bool, error) {
 	return constraint.Check(ver), nil
 }
 
-func checkInitCrdJobs(kubeClient manifest.ExecClient, currentValues, _ *v1alpha2.IstioControlPlaneSpec) util.Errors {
-	pl, err := kubeClient.PodsForSelector(currentValues.DefaultNamespace, "")
+func checkInitCrdJobs(kubeClient manifest.ExecClient, currentICPS, _ *v1alpha2.IstioControlPlaneSpec) util.Errors {
+	pl, err := kubeClient.PodsForSelector(currentICPS.DefaultNamespace, "")
 	if err != nil {
 		return util.NewErrs(fmt.Errorf("failed to list pods: %v", err))
 	}


### PR DESCRIPTION
Fix: https://github.com/istio/istio/issues/19135

Before this change, we used the values in Values API from the configmap of istio-sidecar-injector and the generated ICPS Values section, as the source of old and new installation configurations, which can cause some problems described in https://github.com/istio/istio/issues/19135.

This PR switches the comparison from Values-based to ICPS-based.


------
Related: https://github.com/istio/istio/issues/19451
I also get the kubectl outputs back at cmd/mesh/manifest-common.go:L85, which was removed by mistake, I think.

