### PR TITLE
Add nil check when determining reflect.Kind of types

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -40,7 +40,7 @@ MODIFY
 1. set v1 to v1new
 
   path: a.b.[name:n1].value
-  value: v1
+  value: v1new
 
 2. set vv1 to vv3
 

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -38,6 +38,7 @@ a:
     - v1
     - v2
     - v3_regex
+  c:
 `
 	tests := []struct {
 		desc    string
@@ -65,6 +66,7 @@ a:
     - v2
     - v3_regex
     name: n2
+  c:
 `,
 		},
 		{
@@ -86,6 +88,7 @@ a:
     - v2
     - v3_regex
     name: n2
+  c:
 `,
 		},
 		{
@@ -107,6 +110,7 @@ a:
     - v3
     - v3_regex
     name: n2
+  c:
 `,
 		},
 		{
@@ -125,6 +129,7 @@ a:
     - v2
     - v3_regex
     name: n2
+  c:
 `,
 		},
 		{
@@ -144,6 +149,7 @@ a:
     - v1
     - v3_regex
     name: n2
+  c:
 `,
 		},
 		{
@@ -163,8 +169,34 @@ a:
     - v1
     - v2
     name: n2
+  c:
 `,
-		}}
+		},
+		{
+			desc: "UpdateNullNode",
+			path: `a.c`,
+			value: `
+      d: n3`,
+			want: `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-citadel
+  namespace: istio-system
+a:
+  b:
+  - name: n1
+    value: v1
+  - name: n2
+    list: 
+    - v1
+    - v2
+    - v3_regex
+  c:
+    d: n3
+`,
+		},
+	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			rc := &v1alpha2.KubernetesResourcesSpec{}
@@ -355,7 +387,7 @@ spec:
 `,
 		},
 		{
-			desc: "DeleteLeafListentry",
+			desc: "DeleteLeafListEntry",
 			path: `spec.template.spec.containers.[name:galley].command.[--validation-webhook-config-file]`,
 			want: `
 apiVersion: extensions/v1beta1

--- a/pkg/util/reflect.go
+++ b/pkg/util/reflect.go
@@ -21,19 +21,28 @@ import (
 	"github.com/kr/pretty"
 )
 
+// kindOf returns the reflection Kind that represents the dynamic type of value.
+// If value is a nil interface value, kindOf returns reflect.Invalid.
+func kindOf(value interface{}) reflect.Kind {
+	if value == nil {
+		return reflect.Invalid
+	}
+	return reflect.TypeOf(value).Kind()
+}
+
 // IsString reports whether value is a string type.
 func IsString(value interface{}) bool {
-	return reflect.TypeOf(value).Kind() == reflect.String
+	return kindOf(value) == reflect.String
 }
 
 // IsPtr reports whether value is a ptr type.
 func IsPtr(value interface{}) bool {
-	return reflect.TypeOf(value).Kind() == reflect.Ptr
+	return kindOf(value) == reflect.Ptr
 }
 
 // IsMap reports whether value is a map type.
 func IsMap(value interface{}) bool {
-	return reflect.TypeOf(value).Kind() == reflect.Map
+	return kindOf(value) == reflect.Map
 }
 
 // IsMapPtr reports whether v is a map ptr type.
@@ -44,17 +53,16 @@ func IsMapPtr(v interface{}) bool {
 
 // IsSlice reports whether value is a slice type.
 func IsSlice(value interface{}) bool {
-	return reflect.TypeOf(value).Kind() == reflect.Slice
+	return kindOf(value) == reflect.Slice
 }
 
 func IsStruct(value interface{}) bool {
-	return reflect.TypeOf(value).Kind() == reflect.Struct
+	return kindOf(value) == reflect.Struct
 }
 
 // IsSlicePtr reports whether v is a slice ptr type.
 func IsSlicePtr(v interface{}) bool {
-	t := reflect.TypeOf(v)
-	return t.Kind() == reflect.Ptr && t.Elem().Kind() == reflect.Slice
+	return kindOf(v) == reflect.Ptr && reflect.TypeOf(v).Elem().Kind() == reflect.Slice
 }
 
 // IsSliceInterfacePtr reports whether v is a slice ptr type.
@@ -131,7 +139,7 @@ func IsValueNil(value interface{}) bool {
 	if value == nil {
 		return true
 	}
-	switch reflect.TypeOf(value).Kind() {
+	switch kindOf(value) {
 	case reflect.Slice, reflect.Ptr, reflect.Map:
 		return reflect.ValueOf(value).IsNil()
 	}
@@ -206,7 +214,7 @@ func IsEmptyString(value interface{}) bool {
 	if value == nil {
 		return true
 	}
-	switch reflect.TypeOf(value).Kind() {
+	switch kindOf(value) {
 	case reflect.String:
 		if _, ok := value.(string); ok {
 			return value.(string) == ""


### PR DESCRIPTION
Closes [#19463](https://github.com/istio/istio/issues/19463).

I think there still may be problems with the patch operation as it doesn't seem possible to augment existing objects, only to replace them. This PR addresses the issue of a property being null as described in the linked issue but consider the following:

```yaml
apiVersion: install.istio.io/v1alpha2
kind: IstioControlPlane
spec:
  profile: default
  gateways:
    components:
      ingress_gateway:
        k8s:
          overlays:
          - apiVersion: v1
            kind: Service
            name: istio-ingressgateway
            patches:
            - path: metadata.annotations
              value:
                service.beta.kubernetes.io/aws-load-balancer-type: nlb
                service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
```

Applied against a manifest that looks like:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: istio-ingressgateway
  namespace: istio-system
  annotations:
    foo: bar
```

The result is (the property `foo` is overwritten):

```yaml
apiVersion: v1
kind: Service
metadata:
  name: istio-ingressgateway
  namespace: istio-system
  annotations:
    service.beta.kubernetes.io/aws-load-balancer-type: nlb
    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
```

This seems inconsistent with the way that lists are [additive](https://github.com/istio/operator/blob/master/pkg/patch/patch.go#L68) by default. Is this behavior intended?
