### PR TITLE
[release-1.4] Simplify outputs, hide component detail results if no errors. (#683)

### DIFF
--- a/cmd/mesh/manifest-common.go
+++ b/cmd/mesh/manifest-common.go
@@ -81,29 +81,23 @@ func genApplyManifests(setOverlay []string, inFilename string, force bool, dryRu
 	for cn := range manifests {
 		if out[cn].Err != nil {
 			cs := fmt.Sprintf("Component %s - manifest apply returned the following errors:", cn)
-			l.logAndPrintf("\n%s\n%s", cs, strings.Repeat("=", len(cs)))
+			l.logAndPrintf("\n%s", cs)
 			l.logAndPrint("Error: ", out[cn].Err, "\n")
 			gotError = true
 		} else if skippedComponentMap[cn] {
 			continue
-		} else {
-			cs := fmt.Sprintf("Component %s - manifest apply finished successfully:", cn)
-			l.logAndPrintf("\n%s\n%s", cs, strings.Repeat("=", len(cs)))
 		}
 
 		if !ignoreError(out[cn].Stderr) {
-			l.logAndPrint("Error detail:\n", out[cn].Stderr, "\n")
+			l.logAndPrint("Error detail:\n", out[cn].Stderr, "\n", out[cn].Stdout, "\n")
 			gotError = true
-		}
-		if !ignoreError(out[cn].Stderr) {
-			l.logAndPrint(out[cn].Stdout, "\n")
 		}
 	}
 
 	if gotError {
-		l.logAndPrint("\n\n*** Errors were logged during apply operation. Please check component installation logs above. ***\n")
+		l.logAndPrint("\n\n✘ Errors were logged during apply operation. Please check component installation logs above.\n")
 	} else {
-		l.logAndPrint("\n\n*** Success ***\n")
+		l.logAndPrint("\n\n✔ Installation complete\n")
 	}
 
 	return nil

--- a/pkg/manifest/installer.go
+++ b/pkg/manifest/installer.go
@@ -304,11 +304,11 @@ func applyManifest(componentName name.ComponentName, manifestStr string, version
 		stdout += "\n" + stdoutDel
 		stderr += "\n" + stderrDel
 		if err != nil {
-			logAndPrint("✘ Finished pruning objects for component %s.", componentName)
+			logAndPrint("✘ Finished pruning objects for disabled component %s.", componentName)
 			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 		}
 		appliedObjects = append(appliedObjects, delObjects...)
-		logAndPrint("✔ Finished pruning objects for component %s.", componentName)
+		logAndPrint("✔ Finished pruning objects for disabled component %s.", componentName)
 		return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 	}
 

--- a/pkg/manifest/installer.go
+++ b/pkg/manifest/installer.go
@@ -218,11 +218,10 @@ type InstallOptions struct {
 
 // ApplyAll applies all given manifests using kubectl client.
 func ApplyAll(manifests name.ManifestMap, version version.Version, opts *InstallOptions) (CompositeOutput, error) {
-	logAndPrint("Preparing manifests for these components:")
+	log.Infof("Preparing manifests for these components:")
 	for c := range manifests {
-		logAndPrint("- %s", c)
+		log.Infof("- %s", c)
 	}
-	logAndPrint("")
 	log.Infof("Component dependencies tree: \n%s", installTreeString())
 	if err := initK8SRestClient(opts.Kubeconfig, opts.Context); err != nil {
 		return nil, err
@@ -295,6 +294,7 @@ func applyManifest(componentName name.ComponentName, manifestStr string, version
 			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 		}
 
+		logAndPrint("- Pruning objects for disabled component %s...", componentName)
 		delObjects, err := object.ParseK8sObjectsFromYAMLManifest(stdoutGet)
 		if err != nil {
 			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
@@ -304,9 +304,11 @@ func applyManifest(componentName name.ComponentName, manifestStr string, version
 		stdout += "\n" + stdoutDel
 		stderr += "\n" + stderrDel
 		if err != nil {
+			logAndPrint("✘ Finished pruning objects for component %s.", componentName)
 			return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 		}
 		appliedObjects = append(appliedObjects, delObjects...)
+		logAndPrint("✔ Finished pruning objects for component %s.", componentName)
 		return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 	}
 
@@ -327,9 +329,7 @@ func applyManifest(componentName name.ComponentName, manifestStr string, version
 	if componentName != name.IstioBaseComponentName {
 		extraArgs = append(extraArgs, "--prune", "--selector", componentLabel)
 	}
-
-	logAndPrint("Applying manifest for component %s", componentName)
-
+	logAndPrint("- Applying manifest for component %s...", componentName)
 	nsObjects := nsKindObjects(objects)
 	if len(nsObjects) > 0 {
 		mns, err := nsObjects.JSONManifest()
@@ -378,8 +378,12 @@ func applyManifest(componentName name.ComponentName, manifestStr string, version
 	stdoutNonNsCrd, stderrNonNsCrd, err := kubectl.Apply(opts.DryRun, opts.Verbose, opts.Kubeconfig, opts.Context, namespace, m, extraArgs...)
 	stdout += "\n" + stdoutNonNsCrd
 	stderr += "\n" + stderrNonNsCrd
-	logAndPrint("Finished applying manifest for component %s", componentName)
 	appliedObjects = append(appliedObjects, nonNsCrdObjects...)
+	mark := "✔"
+	if err != nil {
+		mark = "✘"
+	}
+	logAndPrint("%s Finished applying manifest for component %s.", mark, componentName)
 	return buildComponentApplyOutput(stdout, stderr, appliedObjects, err), appliedObjects
 }
 


### PR DESCRIPTION
This is a cherry-pick plus modify to address conflicts of https://github.com/istio/operator/pull/683


```
taohe@taohe:~/istio.io/operator$ go build -o /usr/local/google/home/taohe/go/bin/mesh ./cmd/mesh.go ; mesh manifest apply  --set telemetry.enabled=false --wait
- Applying manifest for component Base...
✔ Finished applying manifest for component Base.
- Applying manifest for component Prometheus...
- Applying manifest for component Galley...
- Applying manifest for component Pilot...
- Applying manifest for component Citadel...
- Applying manifest for component Policy...
- Applying manifest for component IngressGateway...
- Applying manifest for component Injector...
- Pruning objects for disabled component Telemetry...
✔ Finished pruning objects for component Telemetry.
✔ Finished applying manifest for component Citadel.
✔ Finished applying manifest for component Prometheus.
✔ Finished applying manifest for component IngressGateway.
✔ Finished applying manifest for component Galley.
✔ Finished applying manifest for component Policy.
✔ Finished applying manifest for component Pilot.
✔ Finished applying manifest for component Injector.


✔ Installation complete
```