### PR TITLE
update(installer): use latest sha for telemetry v2 and owners fix

### DIFF
--- a/cmd/mesh/testdata/manifest-generate/output/all_off.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/all_off.yaml
@@ -5592,6 +5592,19 @@ data:
         action: keep
         regex: istio-citadel;http-monitoring
 
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - istio-control
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
+
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'
       kubernetes_sd_configs:

--- a/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/all_on.yaml
@@ -5646,6 +5646,9 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    verbs: ["get", "list", "watch"]
 ---
 
 
@@ -6296,7 +6299,7 @@ spec:
         - name: ISTIO_META_WORKLOAD_NAME
           value: istio-ingressgateway
         - name: ISTIO_META_OWNER
-          value: kubernetes://api/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
+          value: kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
         - name: ISTIO_META_MESH_ID
           value: cluster.local
         - name: ISTIO_META_POD_NAME
@@ -7020,9 +7023,13 @@ data:
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
+            {{- $first := true }}
             {{- range $index1, $c := .Spec.Containers }}
               {{- range $index2, $p := $c.Ports }}
-                {{if or (ne $index1 0) (ne $index2 0)}},{{end}}{{ structToJSON $p }}
+                {{- if (structToJSON $p) }}
+                {{if not $first}},{{end}}{{ structToJSON $p }}
+                {{- $first = false }}
+                {{- end }}
               {{- end}}
             {{- end}}
             ]
@@ -7060,7 +7067,7 @@ data:
         {{ end }}
         {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
         - name: ISTIO_META_OWNER
-          value: kubernetes://api/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
+          value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
         {{- end}}
         {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
         - name: ISTIO_BOOTSTRAP_OVERRIDE
@@ -7564,6 +7571,16 @@ data:
 
     disablePolicyChecks: true
 
+    # Automatic protocol detection uses a set of heuristics to
+    # determine whether the connection is using TLS or not (on the
+    # server side), as well as the application protocol being used
+    # (e.g., http vs tcp). These heuristics rely on the client sending
+    # the first bits of data. For server first protocols like MySQL,
+    # MongoDB, etc., Envoy will timeout on the protocol detection after
+    # the specified period, defaulting to non mTLS plain TCP
+    # traffic. Set this field to tweak the period that Envoy will wait
+    # for the client to send the first bits of data. (MUST BE >=1ms)
+    protocolDetectionTimeout: 100ms
 
     # This is the k8s ingress service name, update if you used a different name
     ingressService: "istio-ingressgateway"
@@ -8177,7 +8194,6 @@ spec:
   selector:
     matchLabels:
       app: policy
-      release: istio
       istio: mixer
       istio-mixer-type: policy
 ---
@@ -8372,6 +8388,19 @@ data:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
         regex: istio-citadel;http-monitoring
+
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - istio-system
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
 
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'
@@ -10114,7 +10143,6 @@ spec:
   selector:
     matchLabels:
       app: telemetry
-      release: istio
       istio: mixer
       istio-mixer-type: telemetry
 ---

--- a/cmd/mesh/testdata/manifest-generate/output/flag_force.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/flag_force.yaml
@@ -5592,6 +5592,19 @@ data:
         action: keep
         regex: istio-citadel;http-monitoring
 
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - istio-control
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
+
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'
       kubernetes_sd_configs:

--- a/cmd/mesh/testdata/manifest-generate/output/flag_output.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/flag_output.yaml
@@ -5590,6 +5590,19 @@ data:
         action: keep
         regex: istio-citadel;http-monitoring
 
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - cp
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
+
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'
       kubernetes_sd_configs:

--- a/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/flag_output_set_profile.yaml
@@ -5763,7 +5763,6 @@ data:
     accessLogFile: ""
 
     enableEnvoyAccessLogService: false
-    mixerCheckServer: istio-policy.istio-system.svc.cluster.local:9091
     mixerReportServer: istio-telemetry.istio-system.svc.cluster.local:9091
     # reportBatchMaxEntries is the number of requests that are batched before telemetry data is sent to the mixer server
     reportBatchMaxEntries: 100
@@ -5773,6 +5772,16 @@ data:
 
     disablePolicyChecks: true
 
+    # Automatic protocol detection uses a set of heuristics to
+    # determine whether the connection is using TLS or not (on the
+    # server side), as well as the application protocol being used
+    # (e.g., http vs tcp). These heuristics rely on the client sending
+    # the first bits of data. For server first protocols like MySQL,
+    # MongoDB, etc., Envoy will timeout on the protocol detection after
+    # the specified period, defaulting to non mTLS plain TCP
+    # traffic. Set this field to tweak the period that Envoy will wait
+    # for the client to send the first bits of data. (MUST BE >=1ms)
+    protocolDetectionTimeout: 100ms
 
     # This is the k8s ingress service name, update if you used a different name
     ingressService: "istio-ingressgateway"

--- a/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/flag_output_set_values.yaml
@@ -5644,6 +5644,9 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    verbs: ["get", "list", "watch"]
 ---
 
 
@@ -6294,7 +6297,7 @@ spec:
         - name: ISTIO_META_WORKLOAD_NAME
           value: istio-ingressgateway
         - name: ISTIO_META_OWNER
-          value: kubernetes://api/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
+          value: kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
         - name: ISTIO_META_MESH_ID
           value: cluster.local
         - name: ISTIO_META_POD_NAME
@@ -7018,9 +7021,13 @@ data:
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
+            {{- $first := true }}
             {{- range $index1, $c := .Spec.Containers }}
               {{- range $index2, $p := $c.Ports }}
-                {{if or (ne $index1 0) (ne $index2 0)}},{{end}}{{ structToJSON $p }}
+                {{- if (structToJSON $p) }}
+                {{if not $first}},{{end}}{{ structToJSON $p }}
+                {{- $first = false }}
+                {{- end }}
               {{- end}}
             {{- end}}
             ]
@@ -7058,7 +7065,7 @@ data:
         {{ end }}
         {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
         - name: ISTIO_META_OWNER
-          value: kubernetes://api/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
+          value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
         {{- end}}
         {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
         - name: ISTIO_BOOTSTRAP_OVERRIDE
@@ -7562,6 +7569,16 @@ data:
 
     disablePolicyChecks: true
 
+    # Automatic protocol detection uses a set of heuristics to
+    # determine whether the connection is using TLS or not (on the
+    # server side), as well as the application protocol being used
+    # (e.g., http vs tcp). These heuristics rely on the client sending
+    # the first bits of data. For server first protocols like MySQL,
+    # MongoDB, etc., Envoy will timeout on the protocol detection after
+    # the specified period, defaulting to non mTLS plain TCP
+    # traffic. Set this field to tweak the period that Envoy will wait
+    # for the client to send the first bits of data. (MUST BE >=1ms)
+    protocolDetectionTimeout: 100ms
 
     # This is the k8s ingress service name, update if you used a different name
     ingressService: "istio-ingressgateway"
@@ -8175,7 +8192,6 @@ spec:
   selector:
     matchLabels:
       app: policy
-      release: istio
       istio: mixer
       istio-mixer-type: policy
 ---
@@ -8370,6 +8386,19 @@ data:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
         regex: istio-citadel;http-monitoring
+
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - istio-system
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
 
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'
@@ -10112,7 +10141,6 @@ spec:
   selector:
     matchLabels:
       app: telemetry
-      release: istio
       istio: mixer
       istio-mixer-type: telemetry
 ---

--- a/cmd/mesh/testdata/manifest-generate/output/flag_override_values.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/flag_override_values.yaml
@@ -5592,6 +5592,19 @@ data:
         action: keep
         regex: istio-citadel;http-monitoring
 
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - control-plane
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
+
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'
       kubernetes_sd_configs:

--- a/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/flag_set_values.yaml
@@ -5646,6 +5646,9 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    verbs: ["get", "list", "watch"]
 ---
 
 
@@ -6296,7 +6299,7 @@ spec:
         - name: ISTIO_META_WORKLOAD_NAME
           value: istio-ingressgateway
         - name: ISTIO_META_OWNER
-          value: kubernetes://api/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
+          value: kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
         - name: ISTIO_META_MESH_ID
           value: cluster.local
         - name: ISTIO_META_POD_NAME
@@ -7020,9 +7023,13 @@ data:
         - name: ISTIO_META_POD_PORTS
           value: |-
             [
+            {{- $first := true }}
             {{- range $index1, $c := .Spec.Containers }}
               {{- range $index2, $p := $c.Ports }}
-                {{if or (ne $index1 0) (ne $index2 0)}},{{end}}{{ structToJSON $p }}
+                {{- if (structToJSON $p) }}
+                {{if not $first}},{{end}}{{ structToJSON $p }}
+                {{- $first = false }}
+                {{- end }}
               {{- end}}
             {{- end}}
             ]
@@ -7060,7 +7067,7 @@ data:
         {{ end }}
         {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
         - name: ISTIO_META_OWNER
-          value: kubernetes://api/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
+          value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
         {{- end}}
         {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
         - name: ISTIO_BOOTSTRAP_OVERRIDE
@@ -7564,6 +7571,16 @@ data:
 
     disablePolicyChecks: true
 
+    # Automatic protocol detection uses a set of heuristics to
+    # determine whether the connection is using TLS or not (on the
+    # server side), as well as the application protocol being used
+    # (e.g., http vs tcp). These heuristics rely on the client sending
+    # the first bits of data. For server first protocols like MySQL,
+    # MongoDB, etc., Envoy will timeout on the protocol detection after
+    # the specified period, defaulting to non mTLS plain TCP
+    # traffic. Set this field to tweak the period that Envoy will wait
+    # for the client to send the first bits of data. (MUST BE >=1ms)
+    protocolDetectionTimeout: 100ms
 
     # This is the k8s ingress service name, update if you used a different name
     ingressService: "istio-ingressgateway"
@@ -8177,7 +8194,6 @@ spec:
   selector:
     matchLabels:
       app: policy
-      release: istio
       istio: mixer
       istio-mixer-type: policy
 ---
@@ -8372,6 +8388,19 @@ data:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
         regex: istio-citadel;http-monitoring
+
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - istio-system
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
 
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'
@@ -10114,7 +10143,6 @@ spec:
   selector:
     matchLabels:
       app: telemetry
-      release: istio
       istio: mixer
       istio-mixer-type: telemetry
 ---

--- a/cmd/mesh/testdata/manifest-generate/output/pilot_default.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/pilot_default.yaml
@@ -5762,7 +5762,6 @@ data:
     accessLogFile: ""
 
     enableEnvoyAccessLogService: false
-    mixerCheckServer: istio-policy.istio-control.svc.cluster.local:15004
     mixerReportServer: istio-telemetry.istio-control.svc.cluster.local:15004
     # reportBatchMaxEntries is the number of requests that are batched before telemetry data is sent to the mixer server
     reportBatchMaxEntries: 100
@@ -5772,6 +5771,16 @@ data:
 
     disablePolicyChecks: true
 
+    # Automatic protocol detection uses a set of heuristics to
+    # determine whether the connection is using TLS or not (on the
+    # server side), as well as the application protocol being used
+    # (e.g., http vs tcp). These heuristics rely on the client sending
+    # the first bits of data. For server first protocols like MySQL,
+    # MongoDB, etc., Envoy will timeout on the protocol detection after
+    # the specified period, defaulting to non mTLS plain TCP
+    # traffic. Set this field to tweak the period that Envoy will wait
+    # for the client to send the first bits of data. (MUST BE >=1ms)
+    protocolDetectionTimeout: 100ms
 
     # This is the k8s ingress service name, update if you used a different name
     ingressService: "istio-ingressgateway"
@@ -6263,6 +6272,19 @@ data:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
         regex: istio-citadel;http-monitoring
+
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - istio-control
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
 
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'

--- a/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/pilot_k8s_settings.yaml
@@ -5762,7 +5762,6 @@ data:
     accessLogFile: ""
 
     enableEnvoyAccessLogService: false
-    mixerCheckServer: istio-policy.istio-control.svc.cluster.local:15004
     mixerReportServer: istio-telemetry.istio-control.svc.cluster.local:15004
     # reportBatchMaxEntries is the number of requests that are batched before telemetry data is sent to the mixer server
     reportBatchMaxEntries: 100
@@ -5772,6 +5771,16 @@ data:
 
     disablePolicyChecks: true
 
+    # Automatic protocol detection uses a set of heuristics to
+    # determine whether the connection is using TLS or not (on the
+    # server side), as well as the application protocol being used
+    # (e.g., http vs tcp). These heuristics rely on the client sending
+    # the first bits of data. For server first protocols like MySQL,
+    # MongoDB, etc., Envoy will timeout on the protocol detection after
+    # the specified period, defaulting to non mTLS plain TCP
+    # traffic. Set this field to tweak the period that Envoy will wait
+    # for the client to send the first bits of data. (MUST BE >=1ms)
+    protocolDetectionTimeout: 100ms
 
     # This is the k8s ingress service name, update if you used a different name
     ingressService: "istio-ingressgateway"
@@ -6275,6 +6284,19 @@ data:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
         regex: istio-citadel;http-monitoring
+
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - istio-control
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
 
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'

--- a/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/pilot_override_kubernetes.yaml
@@ -5753,7 +5753,6 @@ data:
     accessLogFile: ""
 
     enableEnvoyAccessLogService: false
-    mixerCheckServer: istio-policy.istio-control.svc.cluster.local:15004
     mixerReportServer: istio-telemetry.istio-control.svc.cluster.local:15004
     # reportBatchMaxEntries is the number of requests that are batched before telemetry data is sent to the mixer server
     reportBatchMaxEntries: 100
@@ -5763,6 +5762,16 @@ data:
 
     disablePolicyChecks: true
 
+    # Automatic protocol detection uses a set of heuristics to
+    # determine whether the connection is using TLS or not (on the
+    # server side), as well as the application protocol being used
+    # (e.g., http vs tcp). These heuristics rely on the client sending
+    # the first bits of data. For server first protocols like MySQL,
+    # MongoDB, etc., Envoy will timeout on the protocol detection after
+    # the specified period, defaulting to non mTLS plain TCP
+    # traffic. Set this field to tweak the period that Envoy will wait
+    # for the client to send the first bits of data. (MUST BE >=1ms)
+    protocolDetectionTimeout: 100ms
 
     # This is the k8s ingress service name, update if you used a different name
     ingressService: "istio-ingressgateway"
@@ -6243,6 +6252,19 @@ data:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
         regex: istio-citadel;http-monitoring
+
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - istio-control
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
 
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'

--- a/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/pilot_override_values.yaml
@@ -5762,7 +5762,6 @@ data:
     accessLogFile: ""
 
     enableEnvoyAccessLogService: false
-    mixerCheckServer: istio-policy.istio-control.svc.cluster.local:15004
     mixerReportServer: istio-telemetry.istio-control.svc.cluster.local:15004
     # reportBatchMaxEntries is the number of requests that are batched before telemetry data is sent to the mixer server
     reportBatchMaxEntries: 100
@@ -5772,6 +5771,16 @@ data:
 
     disablePolicyChecks: true
 
+    # Automatic protocol detection uses a set of heuristics to
+    # determine whether the connection is using TLS or not (on the
+    # server side), as well as the application protocol being used
+    # (e.g., http vs tcp). These heuristics rely on the client sending
+    # the first bits of data. For server first protocols like MySQL,
+    # MongoDB, etc., Envoy will timeout on the protocol detection after
+    # the specified period, defaulting to non mTLS plain TCP
+    # traffic. Set this field to tweak the period that Envoy will wait
+    # for the client to send the first bits of data. (MUST BE >=1ms)
+    protocolDetectionTimeout: 100ms
 
     # This is the k8s ingress service name, update if you used a different name
     ingressService: "istio-ingressgateway"
@@ -6263,6 +6272,19 @@ data:
       - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
         regex: istio-citadel;http-monitoring
+
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - istio-control
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
 
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'

--- a/cmd/mesh/testdata/manifest-generate/output/telemetry_default.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/telemetry_default.yaml
@@ -5592,6 +5592,19 @@ data:
         action: keep
         regex: istio-citadel;http-monitoring
 
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - istio-control
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
+
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'
       kubernetes_sd_configs:
@@ -7333,7 +7346,6 @@ spec:
   selector:
     matchLabels:
       app: telemetry
-      release: istio
       istio: mixer
       istio-mixer-type: telemetry
 ---

--- a/cmd/mesh/testdata/manifest-generate/output/telemetry_k8s_settings.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/telemetry_k8s_settings.yaml
@@ -5602,6 +5602,19 @@ data:
         action: keep
         regex: istio-citadel;http-monitoring
 
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - istio-control
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
+
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'
       kubernetes_sd_configs:
@@ -7354,7 +7367,6 @@ spec:
   selector:
     matchLabels:
       app: telemetry
-      release: istio
       istio: mixer
       istio-mixer-type: telemetry
 ---

--- a/cmd/mesh/testdata/manifest-generate/output/telemetry_override_kubernetes.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/telemetry_override_kubernetes.yaml
@@ -5602,6 +5602,19 @@ data:
         action: keep
         regex: istio-citadel;http-monitoring
 
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - istio-control
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
+
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'
       kubernetes_sd_configs:
@@ -6683,7 +6696,6 @@ spec:
   selector:
     matchLabels:
       app: telemetry
-      release: istio
       istio: mixer
       istio-mixer-type: telemetry
 ---

--- a/cmd/mesh/testdata/manifest-generate/output/telemetry_override_values.yaml
+++ b/cmd/mesh/testdata/manifest-generate/output/telemetry_override_values.yaml
@@ -5592,6 +5592,19 @@ data:
         action: keep
         regex: istio-citadel;http-monitoring
 
+    - job_name: 'sidecar-injector'
+
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - istio-control
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-sidecar-injector;http-monitoring
+
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'
       kubernetes_sd_configs:
@@ -7333,7 +7346,6 @@ spec:
   selector:
     matchLabels:
       app: telemetry
-      release: istio
       istio: mixer
       istio-mixer-type: telemetry
 ---

--- a/cmd/mesh/testdata/operator/output/operator-init.yaml
+++ b/cmd/mesh/testdata/operator/output/operator-init.yaml
@@ -4,121 +4,121 @@ metadata:
   creationTimestamp: null
   name: istio-operator
 rules:
-  # istio groups
-  - apiGroups:
-      - authentication.istio.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - config.istio.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - install.istio.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - networking.istio.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.istio.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - security.istio.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  # k8s groups
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - mutatingwebhookconfigurations
-      - validatingwebhookconfigurations
-    verbs:
-      - '*'
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions.apiextensions.k8s.io
-      - customresourcedefinitions
-    verbs:
-      - '*'
-  - apiGroups:
-      - apps
-      - extensions
-    resources:
-      - daemonsets
-      - deployments
-      - deployments/finalizers
-      - ingresses
-      - replicasets
-      - statefulsets
-    verbs:
-      - '*'
-  - apiGroups:
-      - autoscaling
-    resources:
-      - horizontalpodautoscalers
-    verbs:
-      - '*'
-  - apiGroups:
-      - monitoring.coreos.com
-    resources:
-      - servicemonitors
-    verbs:
-      - get
-      - create
-  - apiGroups:
-      - policy
-    resources:
-      - poddisruptionbudgets
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterrolebindings
-      - clusterroles
-      - roles
-      - rolebindings
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-      - endpoints
-      - events
-      - namespaces
-      - pods
-      - persistentvolumeclaims
-      - secrets
-      - services
-      - serviceaccounts
-    verbs:
-      - '*'
+# istio groups
+- apiGroups:
+  - authentication.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - config.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - install.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - security.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+# k8s groups
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions.apiextensions.k8s.io
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/finalizers
+  - ingresses
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - roles
+  - rolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - namespaces
+  - pods
+  - persistentvolumeclaims
+  - secrets
+  - services
+  - serviceaccounts
+  verbs:
+  - '*'
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: istio-operator
 subjects:
-  - kind: ServiceAccount
-    name: istio-operator
-    namespace: istio-operator
+- kind: ServiceAccount
+  name: istio-operator
+  namespace: operator-test-namespace
 roleRef:
   kind: ClusterRole
   name: istio-operator
@@ -136,7 +136,7 @@ spec:
     plural: istiocontrolplanes
     singular: istiocontrolplane
     shortNames:
-      - icp
+    - icp
   scope: Namespaced
   subresources:
     status: {}
@@ -166,9 +166,9 @@ spec:
             https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
           type: object
   versions:
-    - name: v1alpha2
-      served: true
-      storage: true
+  - name: v1alpha2
+    served: true
+    storage: true
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -190,8 +190,8 @@ spec:
         - name: istio-operator
           image: foo.io/istio/operator:1.2.3
           command:
-            - istio-operator
-            - server
+          - istio-operator
+          - server
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -229,9 +229,9 @@ metadata:
   name: istio-operator
 spec:
   ports:
-    - name: http-metrics
-      port: 8383
-      targetPort: 8383
+  - name: http-metrics
+    port: 8383
+    targetPort: 8383
   selector:
     name: istio-operator
 ---

--- a/cmd/mesh/testdata/operator/output/operator-remove.yaml
+++ b/cmd/mesh/testdata/operator/output/operator-remove.yaml
@@ -4,121 +4,121 @@ metadata:
   creationTimestamp: null
   name: istio-operator
 rules:
-  # istio groups
-  - apiGroups:
-      - authentication.istio.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - config.istio.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - install.istio.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - networking.istio.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.istio.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - security.istio.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  # k8s groups
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - mutatingwebhookconfigurations
-      - validatingwebhookconfigurations
-    verbs:
-      - '*'
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions.apiextensions.k8s.io
-      - customresourcedefinitions
-    verbs:
-      - '*'
-  - apiGroups:
-      - apps
-      - extensions
-    resources:
-      - daemonsets
-      - deployments
-      - deployments/finalizers
-      - ingresses
-      - replicasets
-      - statefulsets
-    verbs:
-      - '*'
-  - apiGroups:
-      - autoscaling
-    resources:
-      - horizontalpodautoscalers
-    verbs:
-      - '*'
-  - apiGroups:
-      - monitoring.coreos.com
-    resources:
-      - servicemonitors
-    verbs:
-      - get
-      - create
-  - apiGroups:
-      - policy
-    resources:
-      - poddisruptionbudgets
-    verbs:
-      - '*'
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterrolebindings
-      - clusterroles
-      - roles
-      - rolebindings
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-      - endpoints
-      - events
-      - namespaces
-      - pods
-      - persistentvolumeclaims
-      - secrets
-      - services
-      - serviceaccounts
-    verbs:
-      - '*'
+# istio groups
+- apiGroups:
+  - authentication.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - config.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - install.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - security.istio.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+# k8s groups
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions.apiextensions.k8s.io
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/finalizers
+  - ingresses
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - roles
+  - rolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - namespaces
+  - pods
+  - persistentvolumeclaims
+  - secrets
+  - services
+  - serviceaccounts
+  verbs:
+  - '*'
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: istio-operator
 subjects:
-  - kind: ServiceAccount
-    name: istio-operator
-    namespace: istio-operator
+- kind: ServiceAccount
+  name: istio-operator
+  namespace: operator-test-namespace
 roleRef:
   kind: ClusterRole
   name: istio-operator
@@ -136,7 +136,7 @@ spec:
     plural: istiocontrolplanes
     singular: istiocontrolplane
     shortNames:
-      - icp
+    - icp
   scope: Namespaced
   subresources:
     status: {}
@@ -166,9 +166,9 @@ spec:
             https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
           type: object
   versions:
-    - name: v1alpha2
-      served: true
-      storage: true
+  - name: v1alpha2
+    served: true
+    storage: true
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -190,8 +190,8 @@ spec:
         - name: istio-operator
           image: foo.io/istio/operator:1.2.3
           command:
-            - istio-operator
-            - server
+          - istio-operator
+          - server
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -229,9 +229,9 @@ metadata:
   name: istio-operator
 spec:
   ports:
-    - name: http-metrics
-      port: 8383
-      targetPort: 8383
+  - name: http-metrics
+    port: 8383
+    targetPort: 8383
   selector:
     name: istio-operator
 ---

--- a/installer.sha
+++ b/installer.sha
@@ -1,1 +1,1 @@
-bacd3ace98e2c813c11c6acb7c7fe11a1a8adeb9
+d8d29fffe4222c2e05bc960a0f6a58f14c42aac6


### PR DESCRIPTION
This pulls in the latest installer changes, including fixes to `master` and the telemetry v2 updates. 

Steps:

1. Updated `installer.sha`.
1. `make test`
1. `make gen`
1. `make update-goldens`