### PR TITLE
Fix scripts to not hardcode istio/installer

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -57,13 +57,13 @@ generate-vfs: update-charts
 clean-vfs:
 	@rm -fr pkg/vfs/assets.gen.go
 
-mesh: generate-vfs
+mesh:
 	# First line is for test environment, second is for target. Since these architectures can differ, the workaround
 	# is to build both. TODO: figure out some way to implement this better, e.g. separate test target.
 	go build -o $(GOBIN)/mesh ./cmd/mesh.go
 	STATIC=0 GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh $(TARGET_OUT)/mesh ./cmd/mesh.go
 
-controller: generate-vfs
+controller:
 	go build -o $(GOBIN)/istio-operator ./cmd/manager
 	STATIC=0 GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh $(TARGET_OUT)/istio-operator ./cmd/manager
 

--- a/scripts/run_update_charts.sh
+++ b/scripts/run_update_charts.sh
@@ -24,23 +24,25 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOTDIR=$(dirname "${SCRIPTPATH}")
 
 OPERATOR_DIR="${ROOTDIR}"
-INSTALLER_DIR=$(mktemp -d)
 OUT_DIR="${OPERATOR_DIR}/data/charts"
-SHA="$(cat "${OPERATOR_DIR}"/installer.sha)"
 
-if [[ "$#" -eq 1 ]]; then
-    SHA="${1}"
+if [[ -z "${INSTALLER_DIR:-}" ]]; then
+  # installer dir not specified, clone from github
+  INSTALLER_DIR=$(mktemp -d)
+  SHA="$(cat "${OPERATOR_DIR}"/installer.sha)"
+
+  if [[ "$#" -eq 1 ]]; then
+      SHA="${1}"
+  fi
+
+  git clone https://github.com/istio/installer.git "${INSTALLER_DIR}"
+
+  pushd .
+  cd "${INSTALLER_DIR}"
+  git fetch
+  git checkout "${SHA}"
+  popd
 fi
-
-if [[ ! -d "${INSTALLER_DIR}/installer" ]] ; then
-    git clone https://github.com/istio/installer.git "${INSTALLER_DIR}"
-fi
-
-pushd .
-cd "${INSTALLER_DIR}"
-git fetch
-git checkout "${SHA}"
-popd
 
 # create charts directory if it doesn't exist.
 mkdir -p "${OUT_DIR}"


### PR DESCRIPTION
We cannot be cloning from github blindly, as this will break our private
security builds. This PR adds an option to pass an INSTALLER_DIR option
to the scripts and skip the cloning. Additionally, do not run vfsgen
when you do docker build. This should be an explicit step, otherwise the
code magically changes during a build and you spend all day debugging
it.

I made a bit more changes than minimally needed for the release script so that it follows the same pattern as the other script