### PR TITLE
Fix affinity translation

### DIFF
--- a/cmd/mesh/testdata/manifest-migrate/output/values.yaml
+++ b/cmd/mesh/testdata/manifest-migrate/output/values.yaml
@@ -8,10 +8,6 @@ spec:
       injector:
         enabled: true
         k8s:
-          affinity:
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution: []
-              requiredDuringSchedulingIgnoredDuringExecution: []
           nodeSelector: {}
           replicaCount: 1
           strategy:
@@ -30,10 +26,6 @@ spec:
       galley:
         enabled: true
         k8s:
-          affinity:
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution: []
-              requiredDuringSchedulingIgnoredDuringExecution: []
           nodeSelector: {}
           replicaCount: 1
           resources:
@@ -55,10 +47,6 @@ spec:
       egressGateway:
         enabled: true
         k8s:
-          affinity:
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution: []
-              requiredDuringSchedulingIgnoredDuringExecution: []
           env:
           - name: ISTIO_META_ROUTER_MODE
             value: sni-dnat
@@ -91,10 +79,6 @@ spec:
       ingressGateway:
         enabled: true
         k8s:
-          affinity:
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution: []
-              requiredDuringSchedulingIgnoredDuringExecution: []
           env:
           - name: ISTIO_META_ROUTER_MODE
             value: sni-dnat
@@ -131,10 +115,6 @@ spec:
       policy:
         enabled: true
         k8s:
-          affinity:
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution: []
-              requiredDuringSchedulingIgnoredDuringExecution: []
           env:
           - name: GODEBUG
             value: gctrace=1
@@ -166,10 +146,6 @@ spec:
       citadel:
         enabled: true
         k8s:
-          affinity:
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution: []
-              requiredDuringSchedulingIgnoredDuringExecution: []
           nodeSelector: {}
           replicaCount: 1
           strategy:
@@ -186,10 +162,6 @@ spec:
       telemetry:
         enabled: true
         k8s:
-          affinity:
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution: []
-              requiredDuringSchedulingIgnoredDuringExecution: []
           hpaSpec:
             maxReplicas: 5
             metrics:
@@ -222,10 +194,6 @@ spec:
       pilot:
         enabled: true
         k8s:
-          affinity:
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution: []
-              requiredDuringSchedulingIgnoredDuringExecution: []
           env:
           - name: GODEBUG
             value: gctrace=1
@@ -264,10 +232,14 @@ spec:
       tolerations: []
     galley:
       image: galley
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
     gateways:
       istio-egressgateway:
         connectTimeout: 10s
         drainDuration: 45s
+        podAntiAffinityLabelSelector: []
+        podAntiAffinityTermLabelSelector: []
         ports:
         - name: http2
           port: 80
@@ -304,6 +276,8 @@ spec:
         - name: tcp-dns-tls
           port: 853
           targetPort: 853
+        podAntiAffinityLabelSelector: []
+        podAntiAffinityTermLabelSelector: []
         ports:
         - name: status-port
           port: 15020
@@ -584,11 +558,15 @@ spec:
           kubernetesenv:
             enabled: true
         image: mixer
+        podAntiAffinityLabelSelector: []
+        podAntiAffinityTermLabelSelector: []
       telemetry:
         image: mixer
         loadshedding:
           latencyThreshold: 100ms
           mode: enforce
+        podAntiAffinityLabelSelector: []
+        podAntiAffinityTermLabelSelector: []
         reportBatchMaxEntries: 100
         reportBatchMaxTime: 1s
         sessionAffinityEnabled: false
@@ -612,6 +590,8 @@ spec:
         ingressControllerMode: "OFF"
         ingressService: istio-ingressgateway
       keepaliveMaxServerConnectionAge: 30m
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
       policy:
         enabled: false
       telemetry:
@@ -659,6 +639,8 @@ spec:
           istio-remote: istio-sidecar-injector.istio-remote.svc
       enableNamespacesByDefault: true
       image: citadel
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
       selfSigned: true
       trustDomain: cluster.local
       workloadCertTtl: 2160h
@@ -668,6 +650,8 @@ spec:
       image: sidecar_injector
       injectLabel: istio-injection
       neverInjectSelector: []
+      podAntiAffinityLabelSelector: []
+      podAntiAffinityTermLabelSelector: []
       rewriteAppHTTPProbe: false
       selfSigned: false
     tracing:

--- a/pkg/translate/translate_value.go
+++ b/pkg/translate/translate_value.go
@@ -49,10 +49,6 @@ var (
 		version.NewMinorVersion(1, 4): {
 			APIMapping: map[string]*Translation{},
 			KubernetesPatternMapping: map[string]string{
-				"{{.ValueComponentName}}.podAntiAffinityLabelSelector": "{{.FeatureName}}.Components.{{.ComponentName}}.K8s." +
-					"Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution",
-				"{{.ValueComponentName}}.podAntiAffinityTermLabelSelector": "{{.FeatureName}}.Components.{{.ComponentName}}.K8s." +
-					"Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution",
 				"{{.ValueComponentName}}.env":                   "{{.FeatureName}}.Components.{{.ComponentName}}.K8s.Env",
 				"{{.ValueComponentName}}.autoscaleEnabled":      "{{.FeatureName}}.Components.{{.ComponentName}}.K8s.HpaSpec",
 				"{{.ValueComponentName}}.imagePullPolicy":       "{{.FeatureName}}.Components.{{.ComponentName}}.K8s.ImagePullPolicy",
@@ -387,19 +383,6 @@ func translateEnv(outPath string, value interface{}, cpSpecTree map[string]inter
 	return nil
 }
 
-// translateAffinity translates Affinity related configurations from helm values.yaml tree
-func translateAffinity(outPath string, value interface{}, cpSpecTree map[string]interface{}) error {
-	affinityNode, ok := value.([]interface{})
-	if !ok {
-		return fmt.Errorf("expect affinity node type to be []interface{} but got: %T", affinityNode)
-	}
-	log.Infof("path has value in helm Value.yaml tree, mapping to output path %s", affinityNode)
-	if err := tpath.WriteNode(cpSpecTree, util.ToYAMLPath(outPath), affinityNode); err != nil {
-		return err
-	}
-	return nil
-}
-
 // translateK8sTree is internal method for translating K8s configurations from value.yaml tree.
 func (t *ReverseTranslator) translateK8sTree(valueTree map[string]interface{},
 	cpSpecTree map[string]interface{}) error {
@@ -442,12 +425,6 @@ func (t *ReverseTranslator) translateK8sTree(valueTree map[string]interface{},
 			err := translateEnv(v.OutPath, m, cpSpecTree)
 			if err != nil {
 				return fmt.Errorf("error in translating k8s Env: %s", err)
-			}
-
-		case "podAntiAffinityLabelSelector", "podAntiAffinityTermLabelSelector":
-			err := translateAffinity(v.OutPath, m, cpSpecTree)
-			if err != nil {
-				return fmt.Errorf("error in translating k8s Affinity: %s", err)
 			}
 
 		case "rollingMaxSurge", "rollingMaxUnavailable":

--- a/pkg/translate/translate_value_test.go
+++ b/pkg/translate/translate_value_test.go
@@ -65,9 +65,10 @@ pilot:
   env:
     GODEBUG: gctrace=1
   podAntiAffinityLabelSelector:
-    - labelSelector:
-        matchLabels:
-          testK1: testV1
+  - key: istio
+    operator: In
+    values: pilot
+    topologyKey: "kubernetes.io/hostname"
 global:
   hub: docker.io/istio
   istioNamespace: istio-system
@@ -143,12 +144,6 @@ trafficManagement:
    pilot:
      enabled: true
      k8s:
-       affinity:
-         podAntiAffinity:
-           requiredDuringSchedulingIgnoredDuringExecution:
-           - labelSelector:
-                 matchLabels:
-                   testK1: testV1
        replicaCount: 1
        env:
        - name: GODEBUG
@@ -197,6 +192,11 @@ values:
   pilot:
     image: pilot
     traceSampling: 1
+    podAntiAffinityLabelSelector:
+    - key: istio
+      operator: In
+      values: pilot
+      topologyKey: "kubernetes.io/hostname"
   mixer:
     policy:
       image: mixer


### PR DESCRIPTION
For affinity translation, instead of writing to the k8s spec,which requires extra logic to converting the original format to k8s affinity, just put it in the values pass through to make sure things work correctly. 