### PR TITLE
Add a validation function to check global.mtls.auto && !global.controlPlaneSecurity

### DIFF
--- a/pkg/apis/istio/v1alpha2/validation/validation.go
+++ b/pkg/apis/istio/v1alpha2/validation/validation.go
@@ -31,8 +31,26 @@ const (
 func ValidateConfig(failOnMissingValidation bool, values *v1alpha1.Values, icpls *v1alpha2.IstioControlPlaneSpec) util.Errors {
 	var validationErrors util.Errors
 	validationErrors = util.AppendErrs(validationErrors, validateSubTypes(reflect.ValueOf(values).Elem(), failOnMissingValidation, values, icpls))
-
+	validationErrors = util.AppendErrs(validationErrors, validateFeatures(values, icpls))
 	return validationErrors
+}
+
+// validateFeatures check whether the config sematically make sense. For example, feature X and feature Y can't be enabled together.
+func validateFeatures(values *v1alpha1.Values, _ *v1alpha2.IstioControlPlaneSpec) util.Errors {
+	// var e util.Errors
+	// When automatic mutual TLS is enabled, we check control plane security must also be enabled.
+	g := values.GetGlobal()
+	if g == nil {
+		return nil
+	}
+	m := g.GetMtls()
+	if m == nil {
+		return nil
+	}
+	if m.GetAuto().Value && !g.GetControlPlaneSecurityEnabled().Value {
+		return []error{fmt.Errorf("security: auto mtls is enabled, but control plane security is not enabled")}
+	}
+	return nil
 }
 
 func validateSubTypes(e reflect.Value, failOnMissingValidation bool, values *v1alpha1.Values, icpls *v1alpha2.IstioControlPlaneSpec) util.Errors {

--- a/pkg/apis/istio/v1alpha2/validation/validation.go
+++ b/pkg/apis/istio/v1alpha2/validation/validation.go
@@ -37,7 +37,6 @@ func ValidateConfig(failOnMissingValidation bool, values *v1alpha1.Values, icpls
 
 // validateFeatures check whether the config sematically make sense. For example, feature X and feature Y can't be enabled together.
 func validateFeatures(values *v1alpha1.Values, _ *v1alpha2.IstioControlPlaneSpec) util.Errors {
-	// var e util.Errors
 	// When automatic mutual TLS is enabled, we check control plane security must also be enabled.
 	g := values.GetGlobal()
 	if g == nil {

--- a/pkg/apis/istio/v1alpha2/validation/validation_test.go
+++ b/pkg/apis/istio/v1alpha2/validation/validation_test.go
@@ -74,3 +74,33 @@ func TestValidate(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateFeatures(t *testing.T) {
+	tests := []struct {
+		name       string
+		toValidate *v1alpha1.Values
+		validated  bool
+	}{
+		{
+			name: "automtls checks control plane security",
+			toValidate: &v1alpha1.Values{
+				Global: &v1alpha1.GlobalConfig{
+					ControlPlaneSecurityEnabled: &types.BoolValue{Value: false},
+					Mtls: &v1alpha1.MTLSConfig{
+						Auto: &types.BoolValue{Value: true},
+					},
+				},
+			},
+			validated: false,
+		},
+	}
+	for _, tt := range tests {
+		err := validateFeatures(tt.toValidate, nil)
+		if len(err) != 0 && tt.validated {
+			t.Fatalf("Test %s failed with errors: %+v but supposed to succeed", tt.name, err)
+		}
+		if len(err) == 0 && !tt.validated {
+			t.Fatalf("Test %s failed as it is supposed to fail but succeeded", tt.name)
+		}
+	}
+}


### PR DESCRIPTION
For security sake, this is invalid, `global.mtls.auto && !global.controlPlaneSecurity`.

Fix https://github.com/istio/istio/issues/19494