### PR TITLE
Determine default values based on Kubernetes env

### DIFF
--- a/cmd/mesh/manifest-generate.go
+++ b/cmd/mesh/manifest-generate.go
@@ -71,7 +71,9 @@ func manifestGenerate(args *rootArgs, mgArgs *manifestGenerateArgs, l *Logger) e
 	if err != nil {
 		return err
 	}
-	manifests, _, err := GenManifests(mgArgs.inFilename, overlayFromSet, mgArgs.force, l)
+	// For generate, we may not have access to the kube cluster, so don't rely on kubeconfig
+	// TODO: support optional kubeconfig reading
+	manifests, _, err := GenManifests(mgArgs.inFilename, overlayFromSet, mgArgs.force, nil, l)
 	if err != nil {
 		return err
 	}

--- a/cmd/mesh/operator-remove.go
+++ b/cmd/mesh/operator-remove.go
@@ -88,7 +88,7 @@ func operatorRemove(args *rootArgs, orArgs *operatorRemoveArgs, l *Logger, delet
 		Context:     orArgs.context,
 	}
 
-	if err := manifest.InitK8SRestClient(opts.Kubeconfig, opts.Context); err != nil {
+	if _, err := manifest.InitK8SRestClient(opts.Kubeconfig, opts.Context); err != nil {
 		l.logAndFatal(err)
 	}
 

--- a/cmd/mesh/profile-dump.go
+++ b/cmd/mesh/profile-dump.go
@@ -66,7 +66,9 @@ func profileDump(args []string, rootArgs *rootArgs, pdArgs *profileDumpArgs, l *
 	if len(args) == 1 {
 		profile = args[0]
 	}
-	y, err := genProfile(pdArgs.helmValues, pdArgs.inFilename, profile, "", pdArgs.configPath, true, l)
+	// For profile dump, we may not have access to the kube cluster, so don't rely on kubeconfig
+	// TODO: support optional kubeconfig reading
+	y, err := genProfile(pdArgs.helmValues, pdArgs.inFilename, profile, "", pdArgs.configPath, true, nil, l)
 	if err != nil {
 		return err
 	}

--- a/pkg/manifest/installer.go
+++ b/pkg/manifest/installer.go
@@ -209,9 +209,6 @@ func ApplyAll(manifests name.ManifestMap, version pkgversion.Version, opts *kube
 		log.Infof("- %s", c)
 	}
 	log.Infof("Component dependencies tree: \n%s", installTreeString())
-	if err := InitK8SRestClient(opts.Kubeconfig, opts.Context); err != nil {
-		return nil, err
-	}
 	return applyRecursive(manifests, version, opts)
 }
 
@@ -372,7 +369,7 @@ func GetKubectlGetItems(stdoutGet string) ([]interface{}, error) {
 }
 
 func DeploymentExists(kubeconfig, context, namespace, name string) (bool, error) {
-	if err := InitK8SRestClient(kubeconfig, context); err != nil {
+	if _, err := InitK8SRestClient(kubeconfig, context); err != nil {
 		return false, err
 	}
 
@@ -753,18 +750,18 @@ func buildInstallTreeString(componentName name.ComponentName, prefix string, sb 
 	}
 }
 
-func InitK8SRestClient(kubeconfig, context string) error {
+func InitK8SRestClient(kubeconfig, context string) (*rest.Config, error) {
 	var err error
 	if kubeconfig == currentKubeconfig && context == currentContext && k8sRESTConfig != nil {
-		return nil
+		return nil, nil
 	}
 	currentKubeconfig, currentContext = kubeconfig, context
 
 	k8sRESTConfig, err = defaultRestConfig(kubeconfig, context)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return k8sRESTConfig, nil
 }
 
 func defaultRestConfig(kubeconfig, configContext string) (*rest.Config, error) {


### PR DESCRIPTION
Partially implements https://github.com/istio/istio/issues/19182

This PR adds the ability for certain values to be configured based on
the currently Kubernetes environment. This should be perfectly reliable
for apply and operator, the only problems may arise are with generate.
For now, this just skips these custom modifications. In the future, if
needed, we can add a flag for generate to read from in cluster config as
well, although its a bit suspect because we may generate with one
cluster config and apply to another.

As an initial implementation, this adds support for detecting whether or
not trustworthy jwt tokens are enabled