### PR TITLE
Fallback to previous versions when failing to create translator

### DIFF
--- a/pkg/translate/translate.go
+++ b/pkg/translate/translate.go
@@ -45,9 +45,11 @@ const (
 	HelmValuesEnabledSubpath = "enabled"
 	// HelmValuesNamespaceSubpath is the subpath from the component root to the namespace parameter.
 	HelmValuesNamespaceSubpath = "namespace"
-
 	// devDbg generates lots of output useful in development.
 	devDbg = false
+	// maxFallbackNum is the max number of previous versions that NewTranslator()
+	// or NewReverseTranslator() will attempt by giving configs for that version.
+	maxFallbackNum = 1
 )
 
 var (
@@ -109,7 +111,7 @@ type Translation struct {
 
 // NewTranslator creates a new Translator for minorVersion and returns a ptr to it.
 func NewTranslator(minorVersion version.MinorVersion) (*Translator, error) {
-	return newTranslator(minorVersion, 1)
+	return newTranslator(minorVersion, maxFallbackNum)
 }
 
 func newTranslator(minorVersion version.MinorVersion, fallbackNum uint) (*Translator, error) {

--- a/pkg/translate/translate.go
+++ b/pkg/translate/translate.go
@@ -109,10 +109,22 @@ type Translation struct {
 
 // NewTranslator creates a new Translator for minorVersion and returns a ptr to it.
 func NewTranslator(minorVersion version.MinorVersion) (*Translator, error) {
+	return newTranslator(minorVersion, 1)
+}
+
+func newTranslator(minorVersion version.MinorVersion, fallbackNum uint) (*Translator, error) {
 	v := fmt.Sprintf("%s.%d", minorVersion.MajorVersion, minorVersion.Minor)
 	f := "translateConfig/translateConfig-" + v + ".yaml"
 	b, err := vfs.ReadFile(f)
 	if err != nil {
+		if fallbackNum > 0 && minorVersion.Minor > 0 {
+			major := minorVersion.Major
+			minor := minorVersion.Minor - 1
+			previous := version.NewMinorVersion(major, minor)
+			log.Warnf("could not read translateConfig file for version %s, fallback to version %s",
+				minorVersion, previous)
+			return newTranslator(previous, fallbackNum-1)
+		}
 		return nil, fmt.Errorf("could not read translateConfig file %s: %s", f, err)
 	}
 	t := &Translator{}
@@ -124,6 +136,7 @@ func NewTranslator(minorVersion version.MinorVersion) (*Translator, error) {
 	for c, f := range t.ToFeature {
 		t.featureToComponents[f] = append(t.featureToComponents[f], c)
 	}
+	t.Version = minorVersion
 	return t, nil
 }
 

--- a/pkg/translate/translate_test.go
+++ b/pkg/translate/translate_test.go
@@ -198,3 +198,49 @@ func errToString(err error) string {
 	}
 	return err.Error()
 }
+
+func TestNewTranslator(t *testing.T) {
+	tests := []struct {
+		name         string
+		minorVersion version.MinorVersion
+		wantVer      string
+		wantErr      bool
+	}{
+		{
+			name:         "version 1.3",
+			minorVersion: version.NewMinorVersion(1, 3),
+			wantVer:      "1.3",
+			wantErr:      false,
+		},
+		{
+			name:         "version 1.4",
+			minorVersion: version.NewMinorVersion(1, 4),
+			wantVer:      "1.4",
+			wantErr:      false,
+		},
+		{
+			name:         "version 1.5",
+			minorVersion: version.NewMinorVersion(1, 5),
+			wantVer:      "1.4",
+			wantErr:      false,
+		},
+		{
+			name:         "version 1.6",
+			minorVersion: version.NewMinorVersion(1, 6),
+			wantVer:      "",
+			wantErr:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewTranslator(tt.minorVersion)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewTranslator() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != nil && tt.wantVer != got.Version.String() {
+				t.Errorf("NewTranslator() got = %v, want %v", got.Version.String(), tt.wantVer)
+			}
+		})
+	}
+}

--- a/pkg/translate/translate_value.go
+++ b/pkg/translate/translate_value.go
@@ -138,15 +138,27 @@ func (t *ReverseTranslator) initK8SMapping(valueTree map[string]interface{}) err
 
 // NewReverseTranslator creates a new ReverseTranslator for minorVersion and returns a ptr to it.
 func NewReverseTranslator(minorVersion version.MinorVersion) (*ReverseTranslator, error) {
+	return newReverseTranslator(minorVersion, 1)
+}
+
+func newReverseTranslator(minorVersion version.MinorVersion, fallbackNum uint) (*ReverseTranslator, error) {
 	t := ReverseTranslators[minorVersion]
 	if t == nil {
+		if fallbackNum > 0 && minorVersion.Minor > 0 {
+			major := minorVersion.Major
+			minor := minorVersion.Minor - 1
+			previous := version.NewMinorVersion(major, minor)
+			log.Warnf("no value.yaml translator available for version %s, fallback to version %s",
+				minorVersion, previous)
+			return newReverseTranslator(previous, fallbackNum-1)
+		}
 		return nil, fmt.Errorf("no value.yaml translator available for version %s", minorVersion)
 	}
-
 	err := t.initAPIAndComponentMapping(minorVersion)
 	if err != nil {
 		return nil, fmt.Errorf("error initialize API mapping: %s", err)
 	}
+	t.Version = minorVersion
 	return t, nil
 }
 

--- a/pkg/translate/translate_value.go
+++ b/pkg/translate/translate_value.go
@@ -138,7 +138,7 @@ func (t *ReverseTranslator) initK8SMapping(valueTree map[string]interface{}) err
 
 // NewReverseTranslator creates a new ReverseTranslator for minorVersion and returns a ptr to it.
 func NewReverseTranslator(minorVersion version.MinorVersion) (*ReverseTranslator, error) {
-	return newReverseTranslator(minorVersion, 1)
+	return newReverseTranslator(minorVersion, maxFallbackNum)
 }
 
 func newReverseTranslator(minorVersion version.MinorVersion, fallbackNum uint) (*ReverseTranslator, error) {

--- a/pkg/translate/translate_value_test.go
+++ b/pkg/translate/translate_value_test.go
@@ -419,3 +419,43 @@ autoInjection:
 		})
 	}
 }
+
+func TestNewReverseTranslator(t *testing.T) {
+	tests := []struct {
+		name         string
+		minorVersion version.MinorVersion
+		wantVer      string
+		wantErr      bool
+	}{
+		{
+			name:         "version 1.4",
+			minorVersion: version.NewMinorVersion(1, 4),
+			wantVer:      "1.4",
+			wantErr:      false,
+		},
+		{
+			name:         "version 1.5",
+			minorVersion: version.NewMinorVersion(1, 5),
+			wantVer:      "1.4",
+			wantErr:      false,
+		},
+		{
+			name:         "version 1.6",
+			minorVersion: version.NewMinorVersion(1, 6),
+			wantVer:      "",
+			wantErr:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewReverseTranslator(tt.minorVersion)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewReverseTranslator() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != nil && tt.wantVer != got.Version.String() {
+				t.Errorf("NewReverseTranslator() got = %v, want %v", got.Version.String(), tt.wantVer)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fallback to previous versions when failing to create translator and reversed translator, in case we may forget to update the version specific files (e.g., TranslateConfig and ReverseTranslators Map) when releasing a new minor version. 