### PR TITLE
Set SilenceUsage true to mesh command

### DIFF
--- a/cmd/mesh/root.go
+++ b/cmd/mesh/root.go
@@ -53,8 +53,9 @@ func addFlags(cmd *cobra.Command, rootArgs *rootArgs) {
 // GetRootCmd returns the root of the cobra command-tree.
 func GetRootCmd(args []string) *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   "mesh",
-		Short: "Command line Istio install utility.",
+		Use:          "mesh",
+		Short:        "Command line Istio install utility.",
+		SilenceUsage: true,
 		Long: "This command uses the Istio operator code to generate templates, query configurations and perform " +
 			"utility operations.",
 	}


### PR DESCRIPTION
This patch sets `SilenceUsage` to true.

Currently mesh command always outputs usage when it fails and makes
difficult to find the main error message.

BEFORE

```
$ ./mesh manifest apply --set hub=localhost:5000 --set tag=1578154376
Error: failed to generate and apply manifests, error: failed to generate tree from the set overlay, error: bad path=value: tag=1578154376
Usage:
  mesh manifest apply [flags]
    ... continue usage lines ...
```

AFTER

```
$ ./mesh manifest apply --set hub=localhost:5000 --set tag=1578154376
Error: failed to generate and apply manifests, error: failed to generate tree from the set overlay, error: bad path=value: tag=1578154376
```

Also, some these outputs are no different.

when the command succeeds;

```
$ ./mesh manifest apply 
This will install the default Istio profile into the cluster. Proceed? (y/N) y
- Applying manifest for component Base...
✔ Finished applying manifest for component Base.
- Applying manifest for component Prometheus...
- Applying manifest for component Citadel...
- Applying manifest for component Policy...
- Applying manifest for component IngressGateway...
- Applying manifest for component Injector...
- Applying manifest for component Galley...
- Applying manifest for component Telemetry...
- Applying manifest for component Pilot...
✔ Finished applying manifest for component Citadel.
✔ Finished applying manifest for component Prometheus.
✔ Finished applying manifest for component Galley.
✔ Finished applying manifest for component Policy.
✔ Finished applying manifest for component Injector.
✔ Finished applying manifest for component IngressGateway.
✔ Finished applying manifest for component Pilot.
✔ Finished applying manifest for component Telemetry.


✔ Installation complete
```

`--help` flag is set.

```
$ ./mesh manifest apply  --help
The apply subcommand generates an Istio install manifest and applies it to a cluster.

Usage:
  mesh manifest apply [flags]

Flags:
      --context string               The name of the kubeconfig context to use
  -f, --filename string              Path to file containing IstioControlPlane CustomResource
      --force                        Proceed even with validation errors
  -h, --help                         help for apply
  -c, --kubeconfig string            Path to kube config
      --readiness-timeout duration   Maximum seconds to wait for all Istio resources to be ready. The --wait flag must be set for this flag to apply (default 5m0s)
  -s, --set strings                  Set a value in IstioControlPlane CustomResource. e.g. --set policy.enabled=true.
                                     Overrides the corresponding path value in the selected profile or passed through IstioControlPlane CR
                                     customization file
      --skip-confirmation            skipConfirmation determines whether the user is prompted for confirmation. 
                                     If set to true, the user is not prompted and a Yes response is assumed in all cases.
  -w, --wait                         Wait, if set will wait until all Pods, Services, and minimum number of Pods of a Deployment are in a ready state before the command exits. It will wait for a maximum duration of --readiness-timeout seconds

Global Flags:
      --dry-run       Console/log output only, make no changes.
      --logtostderr   Send logs to stderr.
      --verbose       Verbose output.
```