### PR TITLE
Add various of tag format support in version check of istioctl upgrade

### DIFF
--- a/cmd/mesh/upgrade.go
+++ b/cmd/mesh/upgrade.go
@@ -146,16 +146,6 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l *logger) (err error) {
 				"you can use --force flag to skip the version check if you know the tag is correct", targetTag)
 		}
 	}
-
-	if targetVersion != opversion.OperatorVersionString {
-		if !args.force {
-			return fmt.Errorf("the target version %v is not supported by istioctl %v, "+
-				"please download istioctl %v and run upgrade again", targetVersion,
-				opversion.OperatorVersionString, targetVersion)
-		}
-		l.logAndPrintf("Warning. The target version %v does not equal to the binary version %v",
-			targetVersion, opversion.OperatorVersionString)
-	}
 	l.logAndPrintf("Upgrade - target version: %s\n", targetVersion)
 
 	// Create a kube client from args.kubeConfigPath and  args.context
@@ -188,9 +178,6 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l *logger) (err error) {
 			currentVersion, targetVersion, err)
 	}
 
-	// Read the overridden values from args.inFilename
-	// TODO: Is this correct? Seems to be checking only the overlays under global. Other parts in ICPS can be
-	// overlaid too.
 	overrideValues, _, err := genOverlayICPS(args.inFilename, args.force)
 	if err != nil {
 		return fmt.Errorf("failed to generate override values from file: %v, error: %v", args.inFilename, err)

--- a/pkg/manifest/client.go
+++ b/pkg/manifest/client.go
@@ -21,6 +21,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 
+	"istio.io/operator/pkg/version"
+
 	"istio.io/operator/pkg/util"
 )
 
@@ -107,7 +109,11 @@ func (client *Client) GetIstioVersions(namespace string) ([]ComponentVersion, er
 				errs = util.AppendErr(errs, err)
 			}
 		}
-		server.Version = pv
+		server.Version, err = version.TagToVersionString(pv)
+		if err != nil {
+			tagErr := fmt.Errorf("unable to convert tag %s into version in pod: %v", pv, pod.Spec.Containers)
+			errs = util.AppendErr(errs, tagErr)
+		}
 		res = append(res, server)
 	}
 	return res, errs.ToError()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -29,11 +29,6 @@ const (
 	releasePrefix = "release-"
 )
 
-const (
-	// releasePrefix is the prefix we used in http://gcr.io/istio-release for releases
-	releasePrefix = "release-"
-)
-
 // CompatibilityMapping is a mapping from an Istio operator version and the corresponding recommended and
 // supported versions of Istio.
 type CompatibilityMapping struct {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,11 +16,22 @@ package version
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v2"
 
 	goversion "github.com/hashicorp/go-version"
+)
+
+const (
+	// releasePrefix is the prefix we used in http://gcr.io/istio-release for releases
+	releasePrefix = "release-"
+)
+
+const (
+	// releasePrefix is the prefix we used in http://gcr.io/istio-release for releases
+	releasePrefix = "release-"
 )
 
 // CompatibilityMapping is a mapping from an Istio operator version and the corresponding recommended and
@@ -128,8 +139,28 @@ func (v *CompatibilityMapping) UnmarshalYAML(unmarshal func(interface{}) error) 
 
 // IsVersionString checks whether the given string is a version string
 func IsVersionString(path string) bool {
+	_, err := goversion.NewSemver(path)
+	if err != nil {
+		return false
+	}
 	vs := Version{}
 	return yaml.Unmarshal([]byte(path), &vs) == nil
+}
+
+// TagToVersionString converts an istio container tag into a version string
+func TagToVersionString(path string) (string, error) {
+	path = strings.TrimPrefix(path, releasePrefix)
+	ver, err := goversion.NewSemver(path)
+	if err != nil {
+		return "", err
+	}
+	segments := ver.Segments()
+	fmtParts := make([]string, len(segments))
+	for i, s := range segments {
+		str := strconv.Itoa(s)
+		fmtParts[i] = str
+	}
+	return strings.Join(fmtParts, "."), nil
 }
 
 // MajorVersion represents a major version.

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -188,3 +188,174 @@ func errToString(err error) string {
 	}
 	return err.Error()
 }
+
+func TestIsVersionString(t *testing.T) {
+	tests := []struct {
+		name string
+		ver  string
+		want bool
+	}{
+		{
+			name: "empty",
+			ver:  "",
+			want: false,
+		},
+		{
+			name: "unknown",
+			ver:  "unknown",
+			want: false,
+		},
+		{
+			name: "release branch dev",
+			ver:  "1.4-dev",
+			want: true,
+		},
+		{
+			name: "release",
+			ver:  "1.4.5",
+			want: true,
+		},
+		{
+			name: "incorrect",
+			ver:  "1.4.xxx",
+			want: false,
+		},
+		{
+			name: "dev sha",
+			ver:  "a3703b76cf4745f3d56bf653ed751509be116351",
+			want: false,
+		},
+		{
+			name: "dev sha digit prefix",
+			ver:  "60023b76cf4745f3d56bf653ed751509be116351",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsVersionString(tt.ver); got != tt.want {
+				t.Errorf("IsVersionString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTagToVersionString(t *testing.T) {
+	//type args struct {
+	//	path string
+	//}
+	tests := []struct {
+		name string
+		//args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "1.4.3",
+			want:    "1.4.3",
+			wantErr: false,
+		},
+		{
+			name:    "1.4.3-distroless",
+			want:    "1.4.3",
+			wantErr: false,
+		},
+		{
+			name:    "1.5.0-alpha.0",
+			want:    "1.5.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.5.0-alpha.0-distroless",
+			want:    "1.5.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.2.10",
+			want:    "1.2.10",
+			wantErr: false,
+		},
+		{
+			name:    "1.4.0-beta.5",
+			want:    "1.4.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.3.0-rc.3",
+			want:    "1.3.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.3.0-rc.3-distroless",
+			want:    "1.3.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.5-dev",
+			want:    "1.5.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.5-dev-distroless",
+			want:    "1.5.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.5-alpha.f850909d7ac95501bbb2ae91f57df218bcf7c630",
+			want:    "1.5.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.5-alpha.f850909d7ac95501bbb2ae91f57df218bcf7c630-distroless",
+			want:    "1.5.0",
+			wantErr: false,
+		},
+		{
+			name:    "release-1.3-20200108-10-15",
+			want:    "1.3.0",
+			wantErr: false,
+		},
+		{
+			name:    "release-1.3-latest-daily",
+			want:    "1.3.0",
+			wantErr: false,
+		},
+		{
+			name:    "release-1.3-20200108-10-15-distroless",
+			want:    "1.3.0",
+			wantErr: false,
+		},
+		{
+			name:    "release-1.3-latest-daily-distroless",
+			want:    "1.3.0",
+			wantErr: false,
+		},
+		{
+			name:    "latest",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "latest-distroless",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "999450fd4add69e26ba04d001b811863cba8175b",
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TagToVersionString(tt.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TagToVersionString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("TagToVersionString() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -18,14 +18,17 @@ import (
 	goversion "github.com/hashicorp/go-version"
 
 	pkgversion "istio.io/operator/pkg/version"
+	buildversion "istio.io/pkg/version"
 )
 
 const (
-	// OperatorVersionString is the version string of this operator binary.
-	OperatorVersionString = "1.4.3"
+	// OperatorCodeBaseVersion is the version string from the code base.
+	OperatorCodeBaseVersion = "1.4.3"
 )
 
 var (
+	// OperatorVersionString is the version string of this operator binary.
+	OperatorVersionString string
 	// OperatorBinaryVersion is the Istio operator version.
 	OperatorBinaryVersion pkgversion.Version
 	// OperatorBinaryGoVersion is the Istio operator version in go-version format.
@@ -34,12 +37,17 @@ var (
 
 func init() {
 	var err error
-	operatorVer := OperatorVersionString
-	OperatorBinaryGoVersion, err = goversion.NewVersion(operatorVer)
+	OperatorVersionString = OperatorCodeBaseVersion
+	// If dockerinfo has a tag (e.g., specified by LDFlags), we will use it as the version of operator
+	tag := buildversion.DockerInfo.Tag
+	if pkgversion.IsVersionString(tag) {
+		OperatorVersionString = tag
+	}
+	OperatorBinaryGoVersion, err = goversion.NewVersion(OperatorVersionString)
 	if err != nil {
 		panic(err)
 	}
-	v, err := pkgversion.NewVersionFromString(operatorVer)
+	v, err := pkgversion.NewVersionFromString(OperatorVersionString)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Add various of tag format support in version check of istioctl upgrade.
Please check out the unit test for the supported version formats.

Related: https://github.com/istio/istio/issues/19708