### PR TITLE
Add various of tag format support in version check of istioctl upgrade.

### DIFF
--- a/cmd/mesh/upgrade.go
+++ b/cmd/mesh/upgrade.go
@@ -27,7 +27,7 @@ import (
 	"istio.io/operator/pkg/compare"
 	"istio.io/operator/pkg/hooks"
 	"istio.io/operator/pkg/manifest"
-	opversion "istio.io/operator/version"
+	pkgversion "istio.io/operator/pkg/version"
 	"istio.io/pkg/log"
 )
 
@@ -124,12 +124,12 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l *Logger) (err error) {
 	}
 
 	// Get the target version from the tag in the IOPS
-	targetVersion := targetIOPS.GetTag()
-	if targetVersion != opversion.OperatorVersionString {
+	targetTag := targetIOPS.GetTag()
+	targetVersion, err := pkgversion.TagToVersionString(targetTag)
+	if err != nil {
 		if !args.force {
-			return fmt.Errorf("the target version %v is not supported by istioctl %v, "+
-				"please download istioctl %v and run upgrade again", targetVersion,
-				opversion.OperatorVersionString, targetVersion)
+			return fmt.Errorf("failed to convert the target tag '%s' into a valid version, "+
+				"you can use --force flag to skip the version check if you know the tag is correct", targetTag)
 		}
 	}
 
@@ -155,7 +155,6 @@ func upgrade(rootArgs *rootArgs, args *upgradeArgs, l *Logger) (err error) {
 		return fmt.Errorf("upgrade version check failed: %v -> %v. Error: %v",
 			currentVersion, targetVersion, err)
 	}
-	l.logAndPrintf("Upgrade version check passed: %v -> %v.\n", currentVersion, targetVersion)
 
 	// Read the overridden IOPS from args.inFilename
 	overrideIOPSYaml := ""

--- a/pkg/manifest/client.go
+++ b/pkg/manifest/client.go
@@ -21,6 +21,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 
+	"istio.io/operator/pkg/version"
+
 	"istio.io/operator/pkg/util"
 )
 
@@ -107,7 +109,11 @@ func (client *Client) GetIstioVersions(namespace string) ([]ComponentVersion, er
 				errs = util.AppendErr(errs, err)
 			}
 		}
-		server.Version = pv
+		server.Version, err = version.TagToVersionString(pv)
+		if err != nil {
+			tagErr := fmt.Errorf("unable to convert tag %s into version in pod: %v", pv, pod.Spec.Containers)
+			errs = util.AppendErr(errs, tagErr)
+		}
 		res = append(res, server)
 	}
 	return res, errs.ToError()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,10 +16,16 @@ package version
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	goversion "github.com/hashicorp/go-version"
 	"gopkg.in/yaml.v2"
+)
+
+const (
+	// releasePrefix is the prefix we used in http://gcr.io/istio-release for releases
+	releasePrefix = "release-"
 )
 
 // CompatibilityMapping is a mapping from an Istio operator version and the corresponding recommended and
@@ -133,6 +139,22 @@ func IsVersionString(path string) bool {
 	}
 	vs := Version{}
 	return yaml.Unmarshal([]byte(path), &vs) == nil
+}
+
+// TagToVersionString converts an istio container tag into a version string
+func TagToVersionString(path string) (string, error) {
+	path = strings.TrimPrefix(path, releasePrefix)
+	ver, err := goversion.NewSemver(path)
+	if err != nil {
+		return "", err
+	}
+	segments := ver.Segments()
+	fmtParts := make([]string, len(segments))
+	for i, s := range segments {
+		str := strconv.Itoa(s)
+		fmtParts[i] = str
+	}
+	return strings.Join(fmtParts, "."), nil
 }
 
 // MajorVersion represents a major version.

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -239,3 +239,123 @@ func TestIsVersionString(t *testing.T) {
 		})
 	}
 }
+
+func TestTagToVersionString(t *testing.T) {
+	//type args struct {
+	//	path string
+	//}
+	tests := []struct {
+		name string
+		//args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "1.4.3",
+			want:    "1.4.3",
+			wantErr: false,
+		},
+		{
+			name:    "1.4.3-distroless",
+			want:    "1.4.3",
+			wantErr: false,
+		},
+		{
+			name:    "1.5.0-alpha.0",
+			want:    "1.5.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.5.0-alpha.0-distroless",
+			want:    "1.5.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.2.10",
+			want:    "1.2.10",
+			wantErr: false,
+		},
+		{
+			name:    "1.4.0-beta.5",
+			want:    "1.4.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.3.0-rc.3",
+			want:    "1.3.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.3.0-rc.3-distroless",
+			want:    "1.3.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.5-dev",
+			want:    "1.5.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.5-dev-distroless",
+			want:    "1.5.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.5-alpha.f850909d7ac95501bbb2ae91f57df218bcf7c630",
+			want:    "1.5.0",
+			wantErr: false,
+		},
+		{
+			name:    "1.5-alpha.f850909d7ac95501bbb2ae91f57df218bcf7c630-distroless",
+			want:    "1.5.0",
+			wantErr: false,
+		},
+		{
+			name:    "release-1.3-20200108-10-15",
+			want:    "1.3.0",
+			wantErr: false,
+		},
+		{
+			name:    "release-1.3-latest-daily",
+			want:    "1.3.0",
+			wantErr: false,
+		},
+		{
+			name:    "release-1.3-20200108-10-15-distroless",
+			want:    "1.3.0",
+			wantErr: false,
+		},
+		{
+			name:    "release-1.3-latest-daily-distroless",
+			want:    "1.3.0",
+			wantErr: false,
+		},
+		{
+			name:    "latest",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "latest-distroless",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "999450fd4add69e26ba04d001b811863cba8175b",
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TagToVersionString(tt.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TagToVersionString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("TagToVersionString() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -37,7 +37,7 @@ var (
 
 func init() {
 	var err error
-	OperatorVersionString := OperatorCodeBaseVersion
+	OperatorVersionString = OperatorCodeBaseVersion
 	// If dockerinfo has a tag (e.g., specified by LDFlags), we will use it as the version of operator
 	tag := buildversion.DockerInfo.Tag
 	if pkgversion.IsVersionString(tag) {


### PR DESCRIPTION
Add various of tag format support in version check of istioctl upgrade.
Please check out the unit test for the supported version formats.

Resolve: https://github.com/istio/istio/issues/19708

A similar PR has been pushed into release-1.4: https://github.com/istio/operator/pull/738