### PR TITLE
Fixing the multicluster gateways example

### DIFF
--- a/data/examples/multicluster/values-istio-multicluster-gateways.yaml
+++ b/data/examples/multicluster/values-istio-multicluster-gateways.yaml
@@ -2,7 +2,7 @@ apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   addonComponents:
-    coreDNS:
+    istiocoredns:
       enabled: true
 
   components:


### PR DESCRIPTION
Ref: https://github.com/istio/istio/issues/23155

Looking around this repo, I also see a 
coreDNS entry in the translateConfig, so not sure if that's what isn't working as expected?

https://github.com/istio/operator/blob/master/data/translateConfig/translateConfig-1.5.yaml#L117

